### PR TITLE
Reset daily quests

### DIFF
--- a/Api/Controllers/AuthenticationController.cs
+++ b/Api/Controllers/AuthenticationController.cs
@@ -17,7 +17,7 @@ namespace Api.Controllers
         }
 
         [HttpPost]
-        [Route("login")]
+        [Route("auth/login")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AuthResponseDto))]  // Returns JWT Token
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))] // Validation Errors
         [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))] // Invalid credentials
@@ -54,7 +54,7 @@ namespace Api.Controllers
         }
 
         [HttpPost]
-        [Route("refresh-token")]
+        [Route("auth/refresh-token")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(RefreshResponseDto))]  // Returns JWT Token
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))] // Validation Errors
         [ProducesResponseType(StatusCodes.Status401Unauthorized, Type = typeof(ProblemDetails))] // Invalid credentials

--- a/Api/Controllers/DailyQuestController.cs
+++ b/Api/Controllers/DailyQuestController.cs
@@ -1,6 +1,7 @@
-﻿using System.Security.Claims;
-using Application.Dtos.Quests.DailyQuest;
+﻿using Application.Dtos.Quests.DailyQuest;
 using Application.Interfaces.Quests;
+using Application.Services;
+using Domain.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
@@ -39,12 +40,9 @@ namespace Api.Controllers
             [FromBody] CreateDailyQuestDto createDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            var accountIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(accountIdString) || !int.TryParse(accountIdString, out var accountId))
-                return Unauthorized("Account id is missing or invalid");
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
             createDto.AccountId = accountId;
 

--- a/Api/Controllers/MonthlyQuestController.cs
+++ b/Api/Controllers/MonthlyQuestController.cs
@@ -1,6 +1,7 @@
-﻿using System.Security.Claims;
-using Application.Dtos.Quests.MonthlyQuest;
+﻿using Application.Dtos.Quests.MonthlyQuest;
 using Application.Interfaces.Quests;
+using Application.Services;
+using Domain.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
@@ -39,12 +40,9 @@ namespace Api.Controllers
             [FromBody] CreateMonthlyQuestDto createDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            var accountIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(accountIdString) || !int.TryParse(accountIdString, out var accountId))
-                return Unauthorized("Account id is missing or invalid");
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
             createDto.AccountId = accountId;
 

--- a/Api/Controllers/OneTimeQuestController.cs
+++ b/Api/Controllers/OneTimeQuestController.cs
@@ -1,6 +1,7 @@
-﻿using System.Security.Claims;
-using Application.Dtos.Quests.OneTimeQuest;
+﻿using Application.Dtos.Quests.OneTimeQuest;
 using Application.Interfaces.Quests;
+using Application.Services;
+using Domain.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
@@ -40,12 +41,9 @@ namespace Api.Controllers
             [FromBody] CreateOneTimeQuestDto createDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            var accountIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(accountIdString) || !int.TryParse(accountIdString, out var accountId))
-                return Unauthorized("Account id is missing or invalid");
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
             createDto.AccountId = accountId;
 

--- a/Api/Controllers/SeasonalQuestController.cs
+++ b/Api/Controllers/SeasonalQuestController.cs
@@ -1,6 +1,7 @@
-﻿using System.Security.Claims;
-using Application.Dtos.Quests.SeasonalQuest;
+﻿using Application.Dtos.Quests.SeasonalQuest;
 using Application.Interfaces.Quests;
+using Application.Services;
+using Domain.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
@@ -39,12 +40,9 @@ namespace Api.Controllers
             [FromBody] CreateSeasonalQuestDto createDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            var accountIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(accountIdString) || !int.TryParse(accountIdString, out var accountId))
-                return Unauthorized("Account id is missing or invalid");
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
             createDto.AccountId = accountId;
 

--- a/Api/Controllers/WeeklyQuestController.cs
+++ b/Api/Controllers/WeeklyQuestController.cs
@@ -1,6 +1,7 @@
-﻿using System.Security.Claims;
-using Application.Dtos.Quests.WeeklyQuest;
+﻿using Application.Dtos.Quests.WeeklyQuest;
 using Application.Interfaces.Quests;
+using Application.Services;
+using Domain.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
@@ -39,12 +40,9 @@ namespace Api.Controllers
             [FromBody] CreateWeeklyQuestDto createDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            var accountIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (string.IsNullOrEmpty(accountIdString) || !int.TryParse(accountIdString, out var accountId))
-                return Unauthorized("Account id is missing or invalid");
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
             createDto.AccountId = accountId;
             var createdId = await _service.CreateAsync(createDto, cancellationToken);

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -63,10 +63,11 @@ namespace Api
             ConfigureMiddleware(app);
 
             // Reset daily questes on startup
-            await ResetQuestsAsync(app);
+            ResetQuestsAsync(app);
 
             Log.Information("Application started");
             await app.RunAsync();
+
         }
 
         private static void ConfigureLogger()

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -62,6 +62,9 @@ namespace Api
             // Configure Middleware
             ConfigureMiddleware(app);
 
+            // Reset daily questes on startup
+            //await ResetQuestsAsync(app);
+
             Log.Information("Application started");
             await app.RunAsync();
         }
@@ -139,6 +142,7 @@ namespace Api
             builder.Services.AddScoped<IMonthlyQuestRepository, MonthlyQuestRepository>();
             builder.Services.AddScoped<ISeasonalQuestRepository, SeasonalQuestRepository>();
             builder.Services.AddScoped<IQuestMetadataRepository, QuestMetadataRepository>();
+            builder.Services.AddScoped<IResetQuestsRepository, ResetQuestsRepository>();
 
             // Register Services
             builder.Services.AddScoped<IAccountService, AccountService>();
@@ -149,6 +153,7 @@ namespace Api
             builder.Services.AddScoped<ISeasonalQuestService, SeasonalQuestService>();
             builder.Services.AddScoped<IQuestMetadataService, QuestMetadataService>();
             builder.Services.AddScoped<IAuthService, AuthService>();
+            builder.Services.AddScoped<IQuestResetService, QuestsResetService>();
 
             // Register Validators
             builder.Services.AddValidatorsFromAssemblyContaining<BaseCreateQuestValidator<BaseCreateQuestDto>>();
@@ -229,6 +234,14 @@ namespace Api
 
             var seeder = serviceProvider.GetRequiredService<DataSeeder>();
             await seeder.SeedAsync();
+        }
+
+        private static async Task ResetQuestsAsync(WebApplication app)
+        {
+            using var scope = app.Services.CreateScope();
+            var serviceProvider = scope.ServiceProvider;
+            var questsResetService = serviceProvider.GetRequiredService<IQuestResetService>();
+            await questsResetService.ResetDailyQuestsAsync();
         }
 
         private static void ConfigureMiddleware(WebApplication app)

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -63,7 +63,7 @@ namespace Api
             ConfigureMiddleware(app);
 
             // Reset daily questes on startup
-            //await ResetQuestsAsync(app);
+            await ResetQuestsAsync(app);
 
             Log.Information("Application started");
             await app.RunAsync();

--- a/Application/Interfaces/Quests/IQuestResetService.cs
+++ b/Application/Interfaces/Quests/IQuestResetService.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Interfaces.Quests
+{
+    public interface IQuestResetService
+    {
+        Task ResetDailyQuestsAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/Application/MappingProfiles/DailyQuestProfile.cs
+++ b/Application/MappingProfiles/DailyQuestProfile.cs
@@ -26,7 +26,7 @@ namespace Application.MappingProfiles
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<PatchDailyQuestDto, DailyQuest>()
                 .ForMember(dest => dest.Priority, opt => opt.ConvertUsing(new NullableEnumConverter<PriorityEnum>(), src => src.Priority))
-                .ForMember(dest => dest.IsCompleted, opt => opt.Condition(src => src.IsCompleted.HasValue))
+                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/MonthlyQuestProfile.cs
+++ b/Application/MappingProfiles/MonthlyQuestProfile.cs
@@ -26,7 +26,7 @@ namespace Application.MappingProfiles
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<PatchMonthlyQuestDto, MonthlyQuest>()
                 .ForMember(dest => dest.Priority, opt => opt.ConvertUsing(new NullableEnumConverter<PriorityEnum>(), src => src.Priority))
-                .ForMember(dest => dest.IsCompleted, opt => opt.Condition(src => src.IsCompleted.HasValue))
+                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/OneTimeQuestProfile.cs
+++ b/Application/MappingProfiles/OneTimeQuestProfile.cs
@@ -26,7 +26,7 @@ namespace Application.MappingProfiles
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<PatchOneTimeQuestDto, OneTimeQuest>()
                 .ForMember(dest => dest.Priority, opt => opt.ConvertUsing(new NullableEnumConverter<PriorityEnum>(), src => src.Priority))
-                .ForMember(dest => dest.IsCompleted, opt => opt.Condition(src => src.IsCompleted.HasValue))
+                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/SeasonalQuestProfile.cs
+++ b/Application/MappingProfiles/SeasonalQuestProfile.cs
@@ -26,7 +26,7 @@ namespace Application.MappingProfiles
 
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<PatchSeasonalQuestDto, SeasonalQuest>()
-                .ForMember(dest => dest.IsCompleted, opt => opt.Condition(src => src.IsCompleted.HasValue))
+                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForMember(dest => dest.Priority, opt => opt.ConvertUsing(new NullableEnumConverter<PriorityEnum>(), src => src.Priority))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 

--- a/Application/MappingProfiles/WeeklyQuestProfile.cs
+++ b/Application/MappingProfiles/WeeklyQuestProfile.cs
@@ -28,8 +28,8 @@ namespace Application.MappingProfiles
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<PatchWeeklyQuestDto, WeeklyQuest>()
                 .ForMember(dest => dest.Priority, opt => opt.ConvertUsing(new NullableEnumConverter<PriorityEnum>(), src => src.Priority))
-                .ForMember(dest => dest.IsCompleted, opt => opt.Condition(src => src.IsCompleted.HasValue))
-                .ForMember(dest => dest.Weekdays, opt => opt.MapFrom(src => src.Weekdays.ConvertAll(w => Enum.Parse<WeekdayEnum>(w))))
+                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
+                .ForMember(dest => dest.Weekdays, opt => opt.MapFrom(src => src.Weekdays!.ConvertAll(w => Enum.Parse<WeekdayEnum>(w))))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Application/Services/Quests/DailyQuestService.cs
+++ b/Application/Services/Quests/DailyQuestService.cs
@@ -86,10 +86,12 @@ namespace Application.Services.Quests
                 if (patchDto.EndDate.Value < existingDailyQuest.StartDate.Value)
                     throw new InvalidArgumentException("End date cannot be before the existing start date.");
             }
-            _mapper.Map(patchDto, existingDailyQuest);
 
             if (existingDailyQuest.IsCompleted == false && patchDto.IsCompleted == true)
                 existingDailyQuest.LastCompleted = DateTime.UtcNow;
+
+            _mapper.Map(patchDto, existingDailyQuest);
+
 
             await _repository.UpdateAsync(existingDailyQuest, cancellationToken);
         }

--- a/Application/Services/Quests/DailyQuestService.cs
+++ b/Application/Services/Quests/DailyQuestService.cs
@@ -5,6 +5,7 @@ using Domain.Enum;
 using Domain.Exceptions;
 using Domain.Interfaces;
 using Domain.Models;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Services.Quests
 {
@@ -12,11 +13,16 @@ namespace Application.Services.Quests
     {
         private readonly IDailyQuestRepository _repository;
         private readonly IMapper _mapper;
+        private readonly ILogger<DailyQuestService> _logger;
 
-        public DailyQuestService(IDailyQuestRepository repository, IMapper mapper)
+        public DailyQuestService(
+            IDailyQuestRepository repository,
+            IMapper mapper,
+            ILogger<DailyQuestService> logger)
         {
             _repository = repository;
             _mapper = mapper;
+            _logger = logger;
         }
 
         public async Task<GetDailyQuestDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
@@ -80,16 +86,10 @@ namespace Application.Services.Quests
                 if (patchDto.EndDate.Value < existingDailyQuest.StartDate.Value)
                     throw new InvalidArgumentException("End date cannot be before the existing start date.");
             }
-
-            // **Fix: Manually Preserve IsCompleted Before AutoMapper Mapping**
-            bool previousIsCompleted = existingDailyQuest.IsCompleted;
-
-            // Apply AutoMapper Mapping (Ignores Nulls)
             _mapper.Map(patchDto, existingDailyQuest);
 
-            // **Fix: Restore IsCompleted If Not Provided**
-            if (patchDto.IsCompleted is null)
-                existingDailyQuest.IsCompleted = previousIsCompleted;
+            if (existingDailyQuest.IsCompleted == false && patchDto.IsCompleted == true)
+                existingDailyQuest.LastCompleted = DateTime.UtcNow;
 
             await _repository.UpdateAsync(existingDailyQuest, cancellationToken);
         }

--- a/Application/Services/Quests/MonthlyQuestService.cs
+++ b/Application/Services/Quests/MonthlyQuestService.cs
@@ -75,15 +75,7 @@ namespace Application.Services.Quests
                     throw new InvalidArgumentException("End date cannot be before the existing start date.");
             }
 
-            // **Fix: Manually Preserve IsCompleted Before AutoMapper Mapping**
-            bool previousIsCompleted = existingMonthlyQuest.IsCompleted;
-
-            // Apply AutoMapper Mapping (Ignores Nulls)
             _mapper.Map(patchDto, existingMonthlyQuest);
-
-            // **Fix: Restore IsCompleted If Not Provided**
-            if (patchDto.IsCompleted is null)
-                existingMonthlyQuest.IsCompleted = previousIsCompleted;
 
             await _repository.UpdateAsync(existingMonthlyQuest, cancellationToken);
         }

--- a/Application/Services/Quests/OneTimeQuestService.cs
+++ b/Application/Services/Quests/OneTimeQuestService.cs
@@ -80,15 +80,7 @@ namespace Application.Services.Quests
                     throw new InvalidArgumentException("End date cannot be before the existing start date.");
             }
 
-            // **Fix: Manually Preserve IsCompleted Before AutoMapper Mapping**
-            bool previousIsCompleted = existingOneTimeQuest.IsCompleted;
-
-            // Apply AutoMapper Mapping (Ignores Nulls)
             _mapper.Map(patchDto, existingOneTimeQuest);
-
-            // **Fix: Restore IsCompleted If Not Provided**
-            if (patchDto.IsCompleted is null)
-                existingOneTimeQuest.IsCompleted = previousIsCompleted;
 
             await _repository.UpdateAsync(existingOneTimeQuest, cancellationToken);
         }

--- a/Application/Services/Quests/SeasonalQuestService.cs
+++ b/Application/Services/Quests/SeasonalQuestService.cs
@@ -75,16 +75,7 @@ namespace Application.Services.Quests
                     throw new InvalidArgumentException("End date cannot be before the existing start date.");
             }
 
-            // **Fix: Manually Preserve IsCompleted Before AutoMapper Mapping**
-            bool previousIsCompleted = existingSeasonalQuest.IsCompleted;
-
-            // Apply AutoMapper Mapping (Ignores Nulls)
             _mapper.Map(patchDto, existingSeasonalQuest);
-
-            // **Fix: Restore IsCompleted If Not Provided**
-            if (patchDto.IsCompleted is null)
-                existingSeasonalQuest.IsCompleted = previousIsCompleted;
-
 
             await _repository.UpdateAsync(existingSeasonalQuest, cancellationToken);
         }

--- a/Application/Services/Quests/WeeklyQuestService.cs
+++ b/Application/Services/Quests/WeeklyQuestService.cs
@@ -75,16 +75,11 @@ namespace Application.Services.Quests
                     throw new InvalidArgumentException("End date cannot be before the existing start date.");
             }
 
-            // **Fix: Manually Preserve IsCompleted Before AutoMapper Mapping**
-            bool previousIsCompleted = existingQuest.IsCompleted;
+            // **Fix: Manually Preserve WeekDays Before AutoMapper Mapping**
             List<WeekdayEnum> previousWeekdays = existingQuest.Weekdays;
 
-            // Apply AutoMapper Mapping (Ignores Nulls)
             _mapper.Map(patchDto, existingQuest);
 
-            // **Fix: Restore IsCompleted If Not Provided**
-            if (patchDto.IsCompleted is null)
-                existingQuest.IsCompleted = previousIsCompleted;
             // **Fix: Restore Weekdays If Not Provided**
             if (patchDto.Weekdays is null)
                 existingQuest.Weekdays = previousWeekdays;

--- a/Application/Services/QuestsResetService.cs
+++ b/Application/Services/QuestsResetService.cs
@@ -1,0 +1,21 @@
+﻿using Application.Interfaces.Quests;
+using Domain.Interfaces;
+
+namespace Application.Services
+{
+    public class QuestsResetService : IQuestResetService
+    {
+        private readonly IResetQuestsRepository _resetQuestRepository;
+
+        public QuestsResetService(IResetQuestsRepository resetQuestRepository)
+        {
+            _resetQuestRepository = resetQuestRepository;
+        }
+
+        public async Task ResetDailyQuestsAsync(CancellationToken cancellationToken = default)
+        {
+            await _resetQuestRepository.ResetDailyQuestsAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/Application/Validators/Quests/WeeklyQuest/PatchWeeklyQuestValidator.cs
+++ b/Application/Validators/Quests/WeeklyQuest/PatchWeeklyQuestValidator.cs
@@ -8,11 +8,14 @@ namespace Application.Validators.Quests.WeeklyQuest
     {
         public PatchWeeklyQuestValidator()
         {
-            RuleForEach(x => x.Weekdays)
-                .NotEmpty().WithMessage("Each weekday must be a valid name.")
-                .IsEnumName(typeof(WeekdayEnum), caseSensitive: true)
-                .WithMessage("{PropertyName} must be a valid weekday name: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'.")
-                .When(x => x.Weekdays.Count > 0 && x.Weekdays != null);
+            RuleFor(x => x.Weekdays)
+                .NotEmpty().WithMessage("{PropertyName} can't be empty.")
+                .When(x => x.Weekdays is not null)
+                .ForEach(weekday =>
+                {
+                    weekday.IsEnumName(typeof(WeekdayEnum), caseSensitive: true)
+                        .WithMessage("{PropertyName} must be a valid weekday name: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'.");
+                });
         }
     }
 }

--- a/Domain/Interfaces/IDailyQuestRepository.cs
+++ b/Domain/Interfaces/IDailyQuestRepository.cs
@@ -3,7 +3,5 @@ using Domain.Models;
 
 namespace Domain.Interfaces
 {
-    public interface IDailyQuestRepository : IBaseRepository<DailyQuest>
-    {
-    }
+    public interface IDailyQuestRepository : IBaseRepository<DailyQuest> { }
 }

--- a/Domain/Interfaces/IResetQuestsRepository.cs
+++ b/Domain/Interfaces/IResetQuestsRepository.cs
@@ -1,0 +1,7 @@
+﻿namespace Domain.Interfaces
+{
+    public interface IResetQuestsRepository
+    {
+        Task ResetDailyQuestsAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/Domain/Models/DailyQuest.cs
+++ b/Domain/Models/DailyQuest.cs
@@ -5,6 +5,7 @@ namespace Domain.Models
 {
     public class DailyQuest : QuestBase
     {
+        public DateTime? LastCompleted { get; set; }
         public DailyQuest() : base() { }
         public DailyQuest(int id, string title, string? description, string? emoji, DateTime? startDate, DateTime? endDate, PriorityEnum? priority)
             : base(id, title, description, emoji, startDate, endDate, priority) { }

--- a/Infrastructure/Migrations/20250225173014_AddedLastCompletedColumnToDailyQuests.Designer.cs
+++ b/Infrastructure/Migrations/20250225173014_AddedLastCompletedColumnToDailyQuests.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250225173014_AddedLastCompletedColumnToDailyQuests")]
+    partial class AddedLastCompletedColumnToDailyQuests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20250225173014_AddedLastCompletedColumnToDailyQuests.cs
+++ b/Infrastructure/Migrations/20250225173014_AddedLastCompletedColumnToDailyQuests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedLastCompletedColumnToDailyQuests : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastCompleted",
+                table: "Daily_Quests",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastCompleted",
+                table: "Daily_Quests");
+        }
+    }
+}

--- a/Infrastructure/Persistence/Configuration/DailyQuestConfiguration.cs
+++ b/Infrastructure/Persistence/Configuration/DailyQuestConfiguration.cs
@@ -40,6 +40,9 @@ namespace Infrastructure.Persistence.Configuration
             builder.Property(dq => dq.UpdatedAt)
                 .IsRequired(false);
 
+            builder.Property(dq => dq.LastCompleted)
+                .IsRequired(false);
+
             builder.HasOne(dq => dq.QuestMetadata)
                 .WithOne(qm => qm.DailyQuest)
                 .HasForeignKey<DailyQuest>(dq => dq.Id)

--- a/Infrastructure/Repositories/Quests/ResetQuestsRepository.cs
+++ b/Infrastructure/Repositories/Quests/ResetQuestsRepository.cs
@@ -1,0 +1,26 @@
+﻿using Domain.Interfaces;
+using Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Repositories.Quests
+{
+    public class ResetQuestsRepository : IResetQuestsRepository
+    {
+        private readonly AppDbContext _context;
+
+        public ResetQuestsRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task ResetDailyQuestsAsync(CancellationToken cancellationToken = default)
+        {
+            await _context.DailyQuests
+                .Where(q => q.IsCompleted == true &&
+                            q.LastCompleted.HasValue &&
+                            q.LastCompleted.Value.Date < DateTime.UtcNow.Date)
+                        .ExecuteUpdateAsync(q => q.SetProperty(x => x.IsCompleted, false), cancellationToken)
+                        .ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes several updates to the authentication routes, quest controllers, and services, as well as the addition of a quest reset feature. The most important changes include modifying route paths, enhancing quest creation methods, and adding a new service for resetting quests.

### Authentication Route Updates:
* [`Api/Controllers/AuthenticationController.cs`](diffhunk://#diff-0d92d1cb2951f19ccaa4c33fc3d24a3b4da3e575db1ebc21a53e37261b347d85L20-R20): Updated the routes for login and refresh-token to include the "auth" prefix. [[1]](diffhunk://#diff-0d92d1cb2951f19ccaa4c33fc3d24a3b4da3e575db1ebc21a53e37261b347d85L20-R20) [[2]](diffhunk://#diff-0d92d1cb2951f19ccaa4c33fc3d24a3b4da3e575db1ebc21a53e37261b347d85L57-R57)

### Quest Controller Enhancements:
* `Api/Controllers/DailyQuestController.cs`, `Api/Controllers/MonthlyQuestController.cs`, `Api/Controllers/OneTimeQuestController.cs`, `Api/Controllers/SeasonalQuestController.cs`, `Api/Controllers/WeeklyQuestController.cs`: Replaced the claims-based account ID retrieval with JWT-based retrieval and introduced better error handling by throwing `UnauthorizedException`. [[1]](diffhunk://#diff-c30315ff6190643a368a040743112ede971267237ea989848d5bda883cdcb79aL42-R45) [[2]](diffhunk://#diff-98e08a5485480a9439a814ab3bbbe60a7a13de711a8639bff43148fbdcf4d008L42-R45) [[3]](diffhunk://#diff-1e11720ca1e66cfd93994eecbcf6140b5962b6e810180dd54f53a222d081bc23L43-R46) [[4]](diffhunk://#diff-d71bd2a8dbd210c128f50d57f3e78c5f5725ccad601ccf44e381093d0f34aa41L42-R45) [[5]](diffhunk://#diff-488be85508d57b4d145f708b19488a422aa68e7463ac532962e8758297ddbc94L42-R45)

### Quest Reset Feature:
* [`Api/Program.cs`](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR65-R70): Added the `ResetQuestsAsync` method to reset daily quests on startup and registered the `IQuestResetService` and `IResetQuestsRepository` services. [[1]](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR65-R70) [[2]](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR146) [[3]](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR157) [[4]](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR240-R247)
* [`Application/Interfaces/Quests/IQuestResetService.cs`](diffhunk://#diff-f17797e12a64094e6c7c4dd1999be7397267fbe77e53f1a6e5a0370380ba93beR1-R7): Introduced the `IQuestResetService` interface with a method to reset daily quests.

### Quest Service and Profile Updates:
* `Application/MappingProfiles/DailyQuestProfile.cs`, `Application/MappingProfiles/MonthlyQuestProfile.cs`, `Application/MappingProfiles/OneTimeQuestProfile.cs`, `Application/MappingProfiles/SeasonalQuestProfile.cs`, `Application/MappingProfiles/WeeklyQuestProfile.cs`: Modified the mapping logic to correctly handle the `IsCompleted` property. [[1]](diffhunk://#diff-af12359dc8d8b20362c579652c1c2cf1ef64eb2f6ac3f0f4483b329682f1e2c5L29-R29) [[2]](diffhunk://#diff-aef632f45b79b85d95c8da32ed1a0fd2d4fc9ab36be4b9354a1852adb94cf3b7L29-R29) [[3]](diffhunk://#diff-4cbc2deb25a4def433891278da12248265da37cff7904fd660138ab3cc843d76L29-R29) [[4]](diffhunk://#diff-4e4966ee458d7d1775ca380f1a8d37e48dea0a6c74c8c47f575e45b52753cdb0L29-R29) [[5]](diffhunk://#diff-d4ac458cadee8cea7cefbfa9f06c9031c3e5c0c26d0957835fb7499cef050876L31-R32)
* `Application/Services/Quests/DailyQuestService.cs`, `Application/Services/Quests/MonthlyQuestService.cs`, `Application/Services/Quests/OneTimeQuestService.cs`: Updated the patch methods to correctly set the `LastCompleted` date when a quest is marked as completed. [[1]](diffhunk://#diff-c096a23d3bbc031826d2e6cb2057104961ead5f4443c4876a04f02a907d55707L84-L92) [[2]](diffhunk://#diff-cddc5356eae4ef85614fdd852a4b924e8cce5e5393f5eba30f7c8a9066f4dff3L78-L87) [[3]](diffhunk://#diff-887f1147d966f5a944d17ac62f08cb07e4cec4b8f0804abbaa60cf65bf1b3b2aL83-L92)