### PR TITLE
Account id validation on request

### DIFF
--- a/Api/Controllers/AllQuestsController.cs
+++ b/Api/Controllers/AllQuestsController.cs
@@ -2,12 +2,14 @@
 using Application.Interfaces.Quests;
 using Application.Services;
 using Domain.Exceptions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
 {
     [ApiController]
     [Route("api/all-quests")]
+    [Authorize]
     public class AllQuestsController : ControllerBase
     {
         private readonly IQuestMetadataService _questMetadataService;
@@ -22,7 +24,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             return Ok(await _questMetadataService.GetAllQuestsAsync(accountId, cancellationToken));
         }

--- a/Api/Controllers/AllQuestsController.cs
+++ b/Api/Controllers/AllQuestsController.cs
@@ -1,5 +1,7 @@
 ﻿using Application.Dtos.Quests.QuestMetadata;
 using Application.Interfaces.Quests;
+using Application.Services;
+using Domain.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
@@ -18,7 +20,11 @@ namespace Api.Controllers
         [HttpGet]
         public async Task<ActionResult<IEnumerable<GetQuestMetadataDto>>> GetAllQuestesAsync(CancellationToken cancellationToken = default)
         {
-            return Ok(await _questMetadataService.GetAllQuestsAsync(cancellationToken));
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+
+            return Ok(await _questMetadataService.GetAllQuestsAsync(accountId, cancellationToken));
         }
     }
 }

--- a/Api/Controllers/DailyQuestController.cs
+++ b/Api/Controllers/DailyQuestController.cs
@@ -71,12 +71,12 @@ namespace Api.Controllers
             [FromBody] PatchDailyQuestDto patchDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.PatchAsync(id, patchDto, cancellationToken);
+            await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
-
         }
 
         [HttpPut("{id}")]
@@ -85,10 +85,11 @@ namespace Api.Controllers
             [FromBody] UpdateDailyQuestDto updateDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.UpdateAsync(id, updateDto, cancellationToken);
+            await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
         }
 

--- a/Api/Controllers/DailyQuestController.cs
+++ b/Api/Controllers/DailyQuestController.cs
@@ -40,9 +40,13 @@ namespace Api.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<GetDailyQuestDto>>> GetAll(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<IEnumerable<GetDailyQuestDto>>> GetAllUserQuests(CancellationToken cancellationToken = default)
         {
-            var quests = await _service.GetAllAsync(cancellationToken);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+
+            var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
         }
 

--- a/Api/Controllers/DailyQuestController.cs
+++ b/Api/Controllers/DailyQuestController.cs
@@ -2,12 +2,14 @@
 using Application.Interfaces.Quests;
 using Application.Services;
 using Domain.Exceptions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
 {
     [ApiController]
     [Route("api/daily-quests")]
+    [Authorize]
     public class DailyQuestController : ControllerBase
     {
         private readonly IDailyQuestService _service;
@@ -22,7 +24,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             var quest = await _service.GetUserQuestByIdAsync(id, accountId, cancellationToken);
 
@@ -44,7 +46,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
@@ -57,7 +59,7 @@ namespace Api.Controllers
         {
             var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             createDto.AccountId = accountId;
 
@@ -73,7 +75,7 @@ namespace Api.Controllers
         {
             var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
@@ -87,7 +89,7 @@ namespace Api.Controllers
         {
             var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
@@ -96,7 +98,12 @@ namespace Api.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(int id, CancellationToken cancellationToken)
         {
-            await _service.DeleteAsync(id, cancellationToken);
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
+
+            await _service.DeleteUserQuestAsync(id, accountId, cancellationToken);
+
             return NoContent();
         }
     }

--- a/Api/Controllers/MonthlyQuestController.cs
+++ b/Api/Controllers/MonthlyQuestController.cs
@@ -70,10 +70,11 @@ namespace Api.Controllers
             [FromBody] PatchMonthlyQuestDto patchDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.PatchAsync(id, patchDto, cancellationToken);
+            await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
 
         }
@@ -84,10 +85,11 @@ namespace Api.Controllers
             [FromBody] UpdateMonthlyQuestDto updateDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.UpdateAsync(id, updateDto, cancellationToken);
+            await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
         }
 

--- a/Api/Controllers/MonthlyQuestController.cs
+++ b/Api/Controllers/MonthlyQuestController.cs
@@ -39,9 +39,13 @@ namespace Api.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<GetMonthlyQuestDto>>> GetAll(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<IEnumerable<GetMonthlyQuestDto>>> GetAllUserQuests(CancellationToken cancellationToken = default)
         {
-            var quests = await _service.GetAllAsync(cancellationToken);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+
+            var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
         }
 

--- a/Api/Controllers/MonthlyQuestController.cs
+++ b/Api/Controllers/MonthlyQuestController.cs
@@ -18,12 +18,22 @@ namespace Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<GetMonthlyQuestDto>> GetById(int id, CancellationToken cancellationToken = default)
+        public async Task<ActionResult<GetMonthlyQuestDto>> GetUserQuestById(int id, CancellationToken cancellationToken = default)
         {
-            var quest = await _service.GetByIdAsync(id, cancellationToken);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
+            var quest = await _service.GetUserQuestByIdAsync(id, accountId, cancellationToken);
             if (quest is null)
-                return NotFound();
+            {
+                return NotFound(new ProblemDetails
+                {
+                    Status = StatusCodes.Status404NotFound,
+                    Title = "Quest not found",
+                    Detail = $"Quest with ID {id} was not found"
+                });
+            }
 
             return Ok(quest);
         }
@@ -47,7 +57,7 @@ namespace Api.Controllers
             createDto.AccountId = accountId;
 
             var createdId = await _service.CreateAsync(createDto, cancellationToken);
-            return CreatedAtAction(nameof(GetById), new { id = createdId }, new { id = createdId });
+            return CreatedAtAction(nameof(GetUserQuestById), new { id = createdId }, new { id = createdId });
         }
 
         [HttpPatch("{id}")]

--- a/Api/Controllers/OneTimeQuestController.cs
+++ b/Api/Controllers/OneTimeQuestController.cs
@@ -41,9 +41,13 @@ namespace Api.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<GetOneTimeQuestDto>>> GetAll(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<IEnumerable<GetOneTimeQuestDto>>> GetAllUserQuests(CancellationToken cancellationToken = default)
         {
-            var quests = await _service.GetAllAsync(cancellationToken);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+
+            var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
         }
 

--- a/Api/Controllers/OneTimeQuestController.cs
+++ b/Api/Controllers/OneTimeQuestController.cs
@@ -67,29 +67,31 @@ namespace Api.Controllers
         }
 
         [HttpPatch("{id}")]
-        public async Task<IActionResult> UpdatePartial(
+        public async Task<IActionResult> UpdateUserQuestPartial(
             int id,
             [FromBody] PatchOneTimeQuestDto patchDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.PatchAsync(id, patchDto, cancellationToken);
+            await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
 
         }
 
         [HttpPut("{id}")]
-        public async Task<IActionResult> Update(
+        public async Task<IActionResult> UpdateUserQuest(
             int id,
             [FromBody] UpdateOneTimeQuestDto updateDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.UpdateAsync(id, updateDto, cancellationToken);
+            await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
         }
 

--- a/Api/Controllers/OneTimeQuestController.cs
+++ b/Api/Controllers/OneTimeQuestController.cs
@@ -2,12 +2,14 @@
 using Application.Interfaces.Quests;
 using Application.Services;
 using Domain.Exceptions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
 {
     [Route("api/one-time-quests")]
     [ApiController]
+    [Authorize]
     public class OneTimeQuestController : ControllerBase
     {
         private readonly IOneTimeQuestService _service;
@@ -23,7 +25,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             var quest = await _service.GetUserQuestByIdAsync(id, accountId, cancellationToken);
 
@@ -45,7 +47,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
@@ -58,7 +60,7 @@ namespace Api.Controllers
         {
             var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             createDto.AccountId = accountId;
 
@@ -74,7 +76,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
@@ -89,7 +91,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
@@ -98,7 +100,11 @@ namespace Api.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(int id, CancellationToken cancellationToken)
         {
-            await _service.DeleteAsync(id, cancellationToken);
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
+
+            await _service.DeleteUserQuestAsync(id, accountId, cancellationToken);
             return NoContent();
         }
     }

--- a/Api/Controllers/SeasonalQuestController.cs
+++ b/Api/Controllers/SeasonalQuestController.cs
@@ -18,12 +18,23 @@ namespace Api.Controllers
         }
 
         [HttpGet("{id}")]
-        public async Task<ActionResult<GetSeasonalQuestDto>> GetById(int id, CancellationToken cancellationToken = default)
+        public async Task<ActionResult<GetSeasonalQuestDto>> GetUserQuestById(int id, CancellationToken cancellationToken = default)
         {
-            var quest = await _service.GetByIdAsync(id, cancellationToken);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+
+            var quest = await _service.GetUserQuestByIdAsync(id, accountId, cancellationToken);
 
             if (quest is null)
-                return NotFound();
+            {
+                return NotFound(new ProblemDetails
+                {
+                    Status = StatusCodes.Status404NotFound,
+                    Title = "Quest not found",
+                    Detail = $"Quest with ID {id} was not found"
+                });
+            }
 
             return Ok(quest);
         }
@@ -47,7 +58,7 @@ namespace Api.Controllers
             createDto.AccountId = accountId;
 
             var createdId = await _service.CreateAsync(createDto, cancellationToken);
-            return CreatedAtAction(nameof(GetById), new { id = createdId }, new { id = createdId });
+            return CreatedAtAction(nameof(GetUserQuestById), new { id = createdId }, new { id = createdId });
         }
 
         [HttpPatch("{id}")]

--- a/Api/Controllers/SeasonalQuestController.cs
+++ b/Api/Controllers/SeasonalQuestController.cs
@@ -40,9 +40,13 @@ namespace Api.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<GetSeasonalQuestDto>>> GetAll(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<IEnumerable<GetSeasonalQuestDto>>> GetAllUserQuests(CancellationToken cancellationToken = default)
         {
-            var quests = await _service.GetAllAsync(cancellationToken);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+
+            var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
         }
 

--- a/Api/Controllers/SeasonalQuestController.cs
+++ b/Api/Controllers/SeasonalQuestController.cs
@@ -66,15 +66,16 @@ namespace Api.Controllers
         }
 
         [HttpPatch("{id}")]
-        public async Task<IActionResult> UpdatePartial(
+        public async Task<IActionResult> UpdateUserQuestPartial(
             int id,
             [FromBody] PatchSeasonalQuestDto patchDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.PatchAsync(id, patchDto, cancellationToken);
+            await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
 
         }
@@ -85,10 +86,11 @@ namespace Api.Controllers
             [FromBody] UpdateSeasonalQuestDto updateDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.UpdateAsync(id, updateDto, cancellationToken);
+            await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
         }
 

--- a/Api/Controllers/SeasonalQuestController.cs
+++ b/Api/Controllers/SeasonalQuestController.cs
@@ -2,12 +2,14 @@
 using Application.Interfaces.Quests;
 using Application.Services;
 using Domain.Exceptions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
 {
     [ApiController]
     [Route("api/seasonal-quests")]
+    [Authorize]
     public class SeasonalQuestController : ControllerBase
     {
         private readonly ISeasonalQuestService _service;
@@ -22,7 +24,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             var quest = await _service.GetUserQuestByIdAsync(id, accountId, cancellationToken);
 
@@ -44,7 +46,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
@@ -57,7 +59,7 @@ namespace Api.Controllers
         {
             var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             createDto.AccountId = accountId;
 
@@ -73,7 +75,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
@@ -88,7 +90,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
@@ -97,7 +99,11 @@ namespace Api.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(int id, CancellationToken cancellationToken)
         {
-            await _service.DeleteAsync(id, cancellationToken);
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
+
+            await _service.DeleteUserQuestAsync(id, accountId, cancellationToken);
             return NoContent();
         }
     }

--- a/Api/Controllers/WeeklyQuestController.cs
+++ b/Api/Controllers/WeeklyQuestController.cs
@@ -65,15 +65,16 @@ namespace Api.Controllers
         }
 
         [HttpPatch("{id}")]
-        public async Task<IActionResult> UpdatePartial(
+        public async Task<IActionResult> UpdateUserQuestPartial(
             int id,
             [FromBody] PatchWeeklyQuestDto patchDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.PatchAsync(id, patchDto, cancellationToken);
+            await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
 
         }
@@ -84,10 +85,11 @@ namespace Api.Controllers
             [FromBody] UpdateWeeklyQuestDto updateDto,
             CancellationToken cancellationToken = default)
         {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
 
-            await _service.UpdateAsync(id, updateDto, cancellationToken);
+            await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
         }
 

--- a/Api/Controllers/WeeklyQuestController.cs
+++ b/Api/Controllers/WeeklyQuestController.cs
@@ -40,9 +40,13 @@ namespace Api.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<GetWeeklyQuestDto>>> GetAll(CancellationToken cancellationToken = default)
+        public async Task<ActionResult<IEnumerable<GetWeeklyQuestDto>>> GetAllUserQuests(CancellationToken cancellationToken = default)
         {
-            var quests = await _service.GetAllAsync(cancellationToken);
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+
+            var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
         }
 

--- a/Api/Controllers/WeeklyQuestController.cs
+++ b/Api/Controllers/WeeklyQuestController.cs
@@ -2,12 +2,14 @@
 using Application.Interfaces.Quests;
 using Application.Services;
 using Domain.Exceptions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Controllers
 {
     [ApiController]
     [Route("api/weekly-quests")]
+    [Authorize]
     public class WeeklyQuestController : ControllerBase
     {
         private readonly IWeeklyQuestService _service;
@@ -22,7 +24,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             var quest = await _service.GetUserQuestByIdAsync(id, accountId, cancellationToken);
 
@@ -44,7 +46,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             var quests = await _service.GetAllUserQuestsAsync(accountId, cancellationToken);
             return Ok(quests);
@@ -57,7 +59,7 @@ namespace Api.Controllers
         {
             var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             createDto.AccountId = accountId;
             var createdId = await _service.CreateAsync(createDto, cancellationToken);
@@ -72,7 +74,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             await _service.PatchUserQuestAsync(id, accountId, patchDto, cancellationToken);
             return NoContent();
@@ -87,7 +89,7 @@ namespace Api.Controllers
         {
             string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
             if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
-                throw new UnauthorizedException("Invalid refresh token: missing account identifier.");
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
 
             await _service.UpdateUserQuestAsync(id, accountId, updateDto, cancellationToken);
             return NoContent();
@@ -96,7 +98,11 @@ namespace Api.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(int id, CancellationToken cancellationToken)
         {
-            await _service.DeleteAsync(id, cancellationToken);
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
+
+            await _service.DeleteUserQuestAsync(id, accountId, cancellationToken);
             return NoContent();
         }
     }

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -63,7 +63,7 @@ namespace Api
             ConfigureMiddleware(app);
 
             // Reset daily questes on startup
-            ResetQuestsAsync(app);
+            ResetQuests(app);
 
             Log.Information("Application started");
             await app.RunAsync();
@@ -237,12 +237,12 @@ namespace Api
             await seeder.SeedAsync();
         }
 
-        private static async Task ResetQuestsAsync(WebApplication app)
+        private static void ResetQuests(WebApplication app)
         {
             using var scope = app.Services.CreateScope();
             var serviceProvider = scope.ServiceProvider;
             var questsResetService = serviceProvider.GetRequiredService<IQuestResetService>();
-            await questsResetService.ResetDailyQuestsAsync();
+            questsResetService.ResetDailyQuestsAsync();
         }
 
         private static void ConfigureMiddleware(WebApplication app)

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -63,11 +63,10 @@ namespace Api
             ConfigureMiddleware(app);
 
             // Reset daily questes on startup
-            ResetQuests(app);
+            await ResetQuests(app);
 
             Log.Information("Application started");
             await app.RunAsync();
-
         }
 
         private static void ConfigureLogger()
@@ -237,12 +236,12 @@ namespace Api
             await seeder.SeedAsync();
         }
 
-        private static void ResetQuests(WebApplication app)
+        private async static Task ResetQuests(WebApplication app)
         {
             using var scope = app.Services.CreateScope();
             var serviceProvider = scope.ServiceProvider;
             var questsResetService = serviceProvider.GetRequiredService<IQuestResetService>();
-            questsResetService.ResetDailyQuestsAsync();
+            await questsResetService.ResetDailyQuestsAsync();
         }
 
         private static void ConfigureMiddleware(WebApplication app)

--- a/Application/Interfaces/Common/IBaseQuestService.cs
+++ b/Application/Interfaces/Common/IBaseQuestService.cs
@@ -13,8 +13,8 @@
         Task<IEnumerable<TDto>> GetAllAsync(CancellationToken cancellationToken = default);
         Task<IEnumerable<TDto>> GetAllUserQuestsAsync(int accountId, CancellationToken cancellationToken = default);
         Task<int> CreateAsync(TCreateDto createDto, CancellationToken cancellationToken = default);
-        Task UpdateAsync(int id, TUpdateDto updateDto, CancellationToken cancellationToken = default);
-        Task PatchAsync(int id, TPatchDto patchDto, CancellationToken cancellationToken = default);
+        Task UpdateUserQuestAsync(int id, int accountId, TUpdateDto updateDto, CancellationToken cancellationToken = default);
+        Task PatchUserQuestAsync(int id, int accountId, TPatchDto patchDto, CancellationToken cancellationToken = default);
         Task DeleteAsync(int id, CancellationToken cancellationToken = default);
     }
 }

--- a/Application/Interfaces/Common/IBaseQuestService.cs
+++ b/Application/Interfaces/Common/IBaseQuestService.cs
@@ -11,6 +11,7 @@
         // For users: Validate if quest belongs to the user
         Task<TDto?> GetUserQuestByIdAsync(int questId, int accountId, CancellationToken cancellationToken = default);
         Task<IEnumerable<TDto>> GetAllAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<TDto>> GetAllUserQuestsAsync(int accountId, CancellationToken cancellationToken = default);
         Task<int> CreateAsync(TCreateDto createDto, CancellationToken cancellationToken = default);
         Task UpdateAsync(int id, TUpdateDto updateDto, CancellationToken cancellationToken = default);
         Task PatchAsync(int id, TPatchDto patchDto, CancellationToken cancellationToken = default);

--- a/Application/Interfaces/Common/IBaseQuestService.cs
+++ b/Application/Interfaces/Common/IBaseQuestService.cs
@@ -15,6 +15,6 @@
         Task<int> CreateAsync(TCreateDto createDto, CancellationToken cancellationToken = default);
         Task UpdateUserQuestAsync(int id, int accountId, TUpdateDto updateDto, CancellationToken cancellationToken = default);
         Task PatchUserQuestAsync(int id, int accountId, TPatchDto patchDto, CancellationToken cancellationToken = default);
-        Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+        Task DeleteUserQuestAsync(int id, int accountId, CancellationToken cancellationToken = default);
     }
 }

--- a/Application/Interfaces/Common/IBaseQuestService.cs
+++ b/Application/Interfaces/Common/IBaseQuestService.cs
@@ -6,7 +6,10 @@
         where TUpdateDto : class
         where TPatchDto : class
     {
-        Task<TDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+        // For admins: No account validation
+        Task<TDto?> GetQuestByIdAsync(int questId, CancellationToken cancellationToken = default);
+        // For users: Validate if quest belongs to the user
+        Task<TDto?> GetUserQuestByIdAsync(int questId, int accountId, CancellationToken cancellationToken = default);
         Task<IEnumerable<TDto>> GetAllAsync(CancellationToken cancellationToken = default);
         Task<int> CreateAsync(TCreateDto createDto, CancellationToken cancellationToken = default);
         Task UpdateAsync(int id, TUpdateDto updateDto, CancellationToken cancellationToken = default);

--- a/Application/Interfaces/Quests/IQuestMetadataService.cs
+++ b/Application/Interfaces/Quests/IQuestMetadataService.cs
@@ -4,6 +4,6 @@ namespace Application.Interfaces.Quests
 {
     public interface IQuestMetadataService
     {
-        Task<IEnumerable<GetQuestMetadataDto>> GetAllQuestsAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<GetQuestMetadataDto>> GetAllQuestsAsync(int accountId, CancellationToken cancellationToken = default);
     }
 }

--- a/Application/Interfaces/Quests/IQuestResetService.cs
+++ b/Application/Interfaces/Quests/IQuestResetService.cs
@@ -2,6 +2,6 @@
 {
     public interface IQuestResetService
     {
-        Task ResetDailyQuestsAsync(CancellationToken cancellationToken = default);
+        void ResetDailyQuestsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Application/Interfaces/Quests/IQuestResetService.cs
+++ b/Application/Interfaces/Quests/IQuestResetService.cs
@@ -2,6 +2,6 @@
 {
     public interface IQuestResetService
     {
-        void ResetDailyQuestsAsync(CancellationToken cancellationToken = default);
+        Task ResetDailyQuestsAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Application/Services/Quests/DailyQuestService.cs
+++ b/Application/Services/Quests/DailyQuestService.cs
@@ -51,6 +51,13 @@ namespace Application.Services.Quests
 
             return _mapper.Map<IEnumerable<GetDailyQuestDto>>(quests);
         }
+        public async Task<IEnumerable<GetDailyQuestDto>> GetAllUserQuestsAsync(int accountId, CancellationToken cancellationToken = default)
+        {
+            var quests = await _repository.GetAllUserQuestsAsync(accountId, cancellationToken)
+                .ConfigureAwait(false);
+
+            return _mapper.Map<IEnumerable<GetDailyQuestDto>>(quests);
+        }
 
         public async Task<int> CreateAsync(CreateDailyQuestDto createDto, CancellationToken cancellationToken = default)
         {

--- a/Application/Services/Quests/DailyQuestService.cs
+++ b/Application/Services/Quests/DailyQuestService.cs
@@ -25,11 +25,24 @@ namespace Application.Services.Quests
             _logger = logger;
         }
 
-        public async Task<GetDailyQuestDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        public async Task<GetDailyQuestDto?> GetQuestByIdAsync(int id, CancellationToken cancellationToken = default)
         {
             var quest = await _repository.GetByIdAsync(id, cancellationToken);
 
             return quest is null ? null : _mapper.Map<GetDailyQuestDto>(quest);
+        }
+
+        public async Task<GetDailyQuestDto?> GetUserQuestByIdAsync(int questId, int accountId, CancellationToken cancellationToken = default)
+        {
+            var quest = await _repository.GetByIdAsync(questId, cancellationToken, dq => dq.QuestMetadata);
+
+            if (quest is null)
+                return null;
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
+
+            return _mapper.Map<GetDailyQuestDto>(quest);
         }
 
         public async Task<IEnumerable<GetDailyQuestDto>> GetAllAsync(CancellationToken cancellationToken = default)

--- a/Application/Services/Quests/DailyQuestService.cs
+++ b/Application/Services/Quests/DailyQuestService.cs
@@ -122,10 +122,13 @@ namespace Application.Services.Quests
             await _repository.UpdateAsync(existingDailyQuest, cancellationToken);
         }
 
-        public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+        public async Task DeleteUserQuestAsync(int id, int accountId, CancellationToken cancellationToken = default)
         {
-            var quest = await _repository.GetByIdAsync(id, cancellationToken)
-                ?? throw new NotFoundException($"DailyQuest with Id {id} was not found.");
+            var quest = await _repository.GetByIdAsync(id, cancellationToken, dq => dq.QuestMetadata).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Quest with Id {id} was not found.");
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             await _repository.DeleteAsync(quest, cancellationToken);
         }

--- a/Application/Services/Quests/DailyQuestService.cs
+++ b/Application/Services/Quests/DailyQuestService.cs
@@ -72,10 +72,13 @@ namespace Application.Services.Quests
             return dailyQuest.Id;
         }
 
-        public async Task UpdateAsync(int id, UpdateDailyQuestDto updateDto, CancellationToken cancellationToken = default)
+        public async Task UpdateUserQuestAsync(int id, int accountId, UpdateDailyQuestDto updateDto, CancellationToken cancellationToken = default)
         {
-            var existingDailyQuest = await _repository.GetByIdAsync(id, cancellationToken)
+            var existingDailyQuest = await _repository.GetByIdAsync(id, cancellationToken, dq => dq.QuestMetadata).ConfigureAwait(false)
                 ?? throw new NotFoundException($"DailyQuest with Id {id} was not found.");
+
+            if (existingDailyQuest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             if (existingDailyQuest.EndDate.HasValue && updateDto.StartDate.HasValue)
             {
@@ -88,10 +91,13 @@ namespace Application.Services.Quests
             await _repository.UpdateAsync(existingDailyQuest, cancellationToken);
         }
 
-        public async Task PatchAsync(int id, PatchDailyQuestDto patchDto, CancellationToken cancellationToken = default)
+        public async Task PatchUserQuestAsync(int id, int accountId, PatchDailyQuestDto patchDto, CancellationToken cancellationToken = default)
         {
-            var existingDailyQuest = await _repository.GetByIdAsync(id, cancellationToken)
+            var existingDailyQuest = await _repository.GetByIdAsync(id, cancellationToken, dq => dq.QuestMetadata).ConfigureAwait(false)
                 ?? throw new NotFoundException($"DailyQuest with Id {id} was not found.");
+
+            if (existingDailyQuest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             // Check if ONLY StartDate is being updated and ensure it's still valid with the existing EndDate
             if (patchDto.StartDate.HasValue && existingDailyQuest.EndDate.HasValue)

--- a/Application/Services/Quests/MonthlyQuestService.cs
+++ b/Application/Services/Quests/MonthlyQuestService.cs
@@ -105,10 +105,13 @@ namespace Application.Services.Quests
             await _repository.UpdateAsync(existingMonthlyQuest, cancellationToken);
         }
 
-        public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+        public async Task DeleteUserQuestAsync(int id, int accountId, CancellationToken cancellationToken = default)
         {
-            var quest = await _repository.GetByIdAsync(id, cancellationToken)
-                ?? throw new NotFoundException($"DailyQuest with Id {id} was not found.");
+            var quest = await _repository.GetByIdAsync(id, cancellationToken, mq => mq.QuestMetadata).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Quest with Id {id} was not found.");
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             await _repository.DeleteAsync(quest, cancellationToken);
         }

--- a/Application/Services/Quests/MonthlyQuestService.cs
+++ b/Application/Services/Quests/MonthlyQuestService.cs
@@ -45,7 +45,13 @@ namespace Application.Services.Quests
 
             return _mapper.Map<IEnumerable<GetMonthlyQuestDto>>(quests);
         }
+        public async Task<IEnumerable<GetMonthlyQuestDto>> GetAllUserQuestsAsync(int accountId, CancellationToken cancellationToken = default)
+        {
+            var quests = await _repository.GetAllUserQuestsAsync(accountId, cancellationToken)
+                .ConfigureAwait(false);
 
+            return _mapper.Map<IEnumerable<GetMonthlyQuestDto>>(quests);
+        }
         public async Task<int> CreateAsync(CreateMonthlyQuestDto createDto, CancellationToken cancellationToken = default)
         {
             var monthlyQuest = _mapper.Map<MonthlyQuest>(createDto);

--- a/Application/Services/Quests/MonthlyQuestService.cs
+++ b/Application/Services/Quests/MonthlyQuestService.cs
@@ -19,11 +19,24 @@ namespace Application.Services.Quests
             _mapper = mapper;
         }
 
-        public async Task<GetMonthlyQuestDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        public async Task<GetMonthlyQuestDto?> GetQuestByIdAsync(int id, CancellationToken cancellationToken = default)
         {
             var quest = await _repository.GetByIdAsync(id, cancellationToken);
 
             return quest is null ? null : _mapper.Map<GetMonthlyQuestDto>(quest);
+        }
+
+        public async Task<GetMonthlyQuestDto?> GetUserQuestByIdAsync(int questId, int accountId, CancellationToken cancellationToken = default)
+        {
+            var quest = await _repository.GetByIdAsync(questId, cancellationToken, mq => mq.QuestMetadata);
+
+            if (quest is null)
+                return null;
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
+
+            return _mapper.Map<GetMonthlyQuestDto>(quest);
         }
 
         public async Task<IEnumerable<GetMonthlyQuestDto>> GetAllAsync(CancellationToken cancellationToken = default)

--- a/Application/Services/Quests/OneTimeQuestService.cs
+++ b/Application/Services/Quests/OneTimeQuestService.cs
@@ -110,10 +110,13 @@ namespace Application.Services.Quests
             await _repository.UpdateAsync(existingOneTimeQuest, cancellationToken);
         }
 
-        public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+        public async Task DeleteUserQuestAsync(int id, int accountId, CancellationToken cancellationToken = default)
         {
-            var quest = await _repository.GetByIdAsync(id, cancellationToken)
-                ?? throw new NotFoundException($"DailyQuest with Id {id} was not found.");
+            var quest = await _repository.GetByIdAsync(id, cancellationToken, otq => otq.QuestMetadata).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Quest with Id {id} was not found.");
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             await _repository.DeleteAsync(quest, cancellationToken);
         }

--- a/Application/Services/Quests/OneTimeQuestService.cs
+++ b/Application/Services/Quests/OneTimeQuestService.cs
@@ -24,11 +24,23 @@ namespace Application.Services.Quests
             _logger = logger;
         }
 
-        public async Task<GetOneTimeQuestDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        public async Task<GetOneTimeQuestDto?> GetQuestByIdAsync(int id, CancellationToken cancellationToken = default)
         {
             var quest = await _repository.GetByIdAsync(id, cancellationToken);
 
             return quest is null ? null : _mapper.Map<GetOneTimeQuestDto>(quest);
+        }
+        public async Task<GetOneTimeQuestDto?> GetUserQuestByIdAsync(int questId, int accountId, CancellationToken cancellationToken = default)
+        {
+            var quest = await _repository.GetByIdAsync(questId, cancellationToken, otq => otq.QuestMetadata);
+
+            if (quest is null)
+                return null;
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
+
+            return _mapper.Map<GetOneTimeQuestDto>(quest);
         }
 
         public async Task<IEnumerable<GetOneTimeQuestDto>> GetAllAsync(CancellationToken cancellationToken = default)

--- a/Application/Services/Quests/OneTimeQuestService.cs
+++ b/Application/Services/Quests/OneTimeQuestService.cs
@@ -49,6 +49,13 @@ namespace Application.Services.Quests
 
             return _mapper.Map<IEnumerable<GetOneTimeQuestDto>>(quests);
         }
+        public async Task<IEnumerable<GetOneTimeQuestDto>> GetAllUserQuestsAsync(int accountId, CancellationToken cancellationToken = default)
+        {
+            var quests = await _repository.GetAllUserQuestsAsync(accountId, cancellationToken)
+                .ConfigureAwait(false);
+
+            return _mapper.Map<IEnumerable<GetOneTimeQuestDto>>(quests);
+        }
 
         public async Task<int> CreateAsync(CreateOneTimeQuestDto createDto, CancellationToken cancellationToken = default)
         {

--- a/Application/Services/Quests/QuestMetadataService.cs
+++ b/Application/Services/Quests/QuestMetadataService.cs
@@ -16,9 +16,9 @@ namespace Application.Services.Quests
             _mapper = mapper;
         }
 
-        public async Task<IEnumerable<GetQuestMetadataDto>> GetAllQuestsAsync(CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<GetQuestMetadataDto>> GetAllQuestsAsync(int accountId, CancellationToken cancellationToken = default)
         {
-            var quests = await _repository.GetTodaysQuestsAsync(cancellationToken)
+            var quests = await _repository.GetTodaysQuestsAsync(accountId, cancellationToken)
                 .ConfigureAwait(false);
 
             return _mapper.Map<IEnumerable<GetQuestMetadataDto>>(quests);

--- a/Application/Services/Quests/SeasonalQuestService.cs
+++ b/Application/Services/Quests/SeasonalQuestService.cs
@@ -19,13 +19,24 @@ namespace Application.Services.Quests
             _mapper = mapper;
         }
 
-        public async Task<GetSeasonalQuestDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        public async Task<GetSeasonalQuestDto?> GetQuestByIdAsync(int id, CancellationToken cancellationToken = default)
         {
             var quest = await _repository.GetByIdAsync(id, cancellationToken);
 
             return quest is null ? null : _mapper.Map<GetSeasonalQuestDto>(quest);
         }
+        public async Task<GetSeasonalQuestDto?> GetUserQuestByIdAsync(int questId, int accountId, CancellationToken cancellationToken = default)
+        {
+            var quest = await _repository.GetByIdAsync(questId, cancellationToken, sq => sq.QuestMetadata);
 
+            if (quest is null)
+                return null;
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
+
+            return _mapper.Map<GetSeasonalQuestDto>(quest);
+        }
         public async Task<IEnumerable<GetSeasonalQuestDto>> GetAllAsync(CancellationToken cancellationToken = default)
         {
             var quests = await _repository.GetAllAsync(cancellationToken);

--- a/Application/Services/Quests/SeasonalQuestService.cs
+++ b/Application/Services/Quests/SeasonalQuestService.cs
@@ -43,7 +43,13 @@ namespace Application.Services.Quests
 
             return _mapper.Map<IEnumerable<GetSeasonalQuestDto>>(quests);
         }
+        public async Task<IEnumerable<GetSeasonalQuestDto>> GetAllUserQuestsAsync(int accountId, CancellationToken cancellationToken = default)
+        {
+            var quests = await _repository.GetAllUserQuestsAsync(accountId, cancellationToken)
+                .ConfigureAwait(false);
 
+            return _mapper.Map<IEnumerable<GetSeasonalQuestDto>>(quests);
+        }
         public async Task<int> CreateAsync(CreateSeasonalQuestDto createDto, CancellationToken cancellationToken = default)
         {
             var seasonalQuest = _mapper.Map<SeasonalQuest>(createDto);

--- a/Application/Services/Quests/SeasonalQuestService.cs
+++ b/Application/Services/Quests/SeasonalQuestService.cs
@@ -63,20 +63,26 @@ namespace Application.Services.Quests
             return seasonalQuest.Id;
         }
 
-        public async Task UpdateAsync(int id, UpdateSeasonalQuestDto updateDto, CancellationToken cancellationToken = default)
+        public async Task UpdateUserQuestAsync(int id, int accountId, UpdateSeasonalQuestDto updateDto, CancellationToken cancellationToken = default)
         {
-            var existingSeasonalQuest = await _repository.GetByIdAsync(id, cancellationToken)
+            var existingSeasonalQuest = await _repository.GetByIdAsync(id, cancellationToken, sq => sq.QuestMetadata).ConfigureAwait(false)
                 ?? throw new NotFoundException($"Quest with Id {id} was not found.");
+
+            if (existingSeasonalQuest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             _mapper.Map(updateDto, existingSeasonalQuest);
 
             await _repository.UpdateAsync(existingSeasonalQuest, cancellationToken);
         }
 
-        public async Task PatchAsync(int id, PatchSeasonalQuestDto patchDto, CancellationToken cancellationToken = default)
+        public async Task PatchUserQuestAsync(int id, int accountId, PatchSeasonalQuestDto patchDto, CancellationToken cancellationToken = default)
         {
-            var existingSeasonalQuest = await _repository.GetByIdAsync(id, cancellationToken)
+            var existingSeasonalQuest = await _repository.GetByIdAsync(id, cancellationToken, sq => sq.QuestMetadata).ConfigureAwait(false)
                 ?? throw new NotFoundException($"Quest with Id {id} was not found.");
+
+            if (existingSeasonalQuest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             // Check if ONLY StartDate is being updated and ensure it's still valid with the existing EndDate
             if (patchDto.StartDate.HasValue && existingSeasonalQuest.EndDate.HasValue)

--- a/Application/Services/Quests/SeasonalQuestService.cs
+++ b/Application/Services/Quests/SeasonalQuestService.cs
@@ -103,10 +103,13 @@ namespace Application.Services.Quests
             await _repository.UpdateAsync(existingSeasonalQuest, cancellationToken);
         }
 
-        public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+        public async Task DeleteUserQuestAsync(int id, int accountId, CancellationToken cancellationToken = default)
         {
-            var quest = await _repository.GetByIdAsync(id, cancellationToken)
-                ?? throw new NotFoundException($"DailyQuest with Id {id} was not found.");
+            var quest = await _repository.GetByIdAsync(id, cancellationToken, sq => sq.QuestMetadata).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Quest with Id {id} was not found.");
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             await _repository.DeleteAsync(quest, cancellationToken);
         }

--- a/Application/Services/Quests/WeeklyQuestService.cs
+++ b/Application/Services/Quests/WeeklyQuestService.cs
@@ -118,10 +118,13 @@ namespace Application.Services.Quests
             await _repository.UpdateAsync(existingQuest, cancellationToken);
         }
 
-        public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+        public async Task DeleteUserQuestAsync(int id, int accountId, CancellationToken cancellationToken = default)
         {
-            var quest = await _repository.GetByIdAsync(id, cancellationToken)
-                ?? throw new NotFoundException($"DailyQuest with Id {id} was not found.");
+            var quest = await _repository.GetByIdAsync(id, cancellationToken, wq => wq.QuestMetadata).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Quest with Id {id} was not found.");
+
+            if (quest.QuestMetadata.AccountId != accountId)
+                throw new UnauthorizedException("You do not have permission to access this quest.");
 
             await _repository.DeleteAsync(quest, cancellationToken);
         }

--- a/Application/Services/Quests/WeeklyQuestService.cs
+++ b/Application/Services/Quests/WeeklyQuestService.cs
@@ -51,7 +51,13 @@ namespace Application.Services.Quests
 
             return _mapper.Map<IEnumerable<GetWeeklyQuestDto>>(quests);
         }
+        public async Task<IEnumerable<GetWeeklyQuestDto>> GetAllUserQuestsAsync(int accountId, CancellationToken cancellationToken = default)
+        {
+            var quests = await _repository.GetAllUserQuestsAsync(accountId, cancellationToken)
+                .ConfigureAwait(false);
 
+            return _mapper.Map<IEnumerable<GetWeeklyQuestDto>>(quests);
+        }
         public async Task<int> CreateAsync(CreateWeeklyQuestDto createDto, CancellationToken cancellationToken = default)
         {
             var weeklyQuest = _mapper.Map<WeeklyQuest>(createDto);

--- a/Application/Services/QuestsResetService.cs
+++ b/Application/Services/QuestsResetService.cs
@@ -12,10 +12,9 @@ namespace Application.Services
             _resetQuestRepository = resetQuestRepository;
         }
 
-        public async Task ResetDailyQuestsAsync(CancellationToken cancellationToken = default)
+        public void ResetDailyQuestsAsync(CancellationToken cancellationToken = default)
         {
-            await _resetQuestRepository.ResetDailyQuestsAsync(cancellationToken)
-                .ConfigureAwait(false);
+            _resetQuestRepository.ResetDailyQuestsAsync(cancellationToken);
         }
     }
 }

--- a/Application/Services/QuestsResetService.cs
+++ b/Application/Services/QuestsResetService.cs
@@ -12,9 +12,9 @@ namespace Application.Services
             _resetQuestRepository = resetQuestRepository;
         }
 
-        public void ResetDailyQuestsAsync(CancellationToken cancellationToken = default)
+        public async Task ResetDailyQuestsAsync(CancellationToken cancellationToken = default)
         {
-            _resetQuestRepository.ResetDailyQuestsAsync(cancellationToken);
+            await _resetQuestRepository.ResetDailyQuestsAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Domain/Interfaces/IBaseRepository.cs
+++ b/Domain/Interfaces/IBaseRepository.cs
@@ -8,6 +8,7 @@ namespace Domain.Interfaces
         {
             Task<T?> GetByIdAsync(int id, CancellationToken cancellationToken = default, params Expression<Func<T, object>>[] includes);
             Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default);
+            Task<IEnumerable<T>> GetAllUserQuestsAsync(int accountId, CancellationToken cancellationToken = default, params Expression<Func<T, object>>[] includes);
             Task AddAsync(T entity, CancellationToken cancellationToken = default);
             Task UpdateAsync(T entity, CancellationToken cancellationToken = default);
             Task DeleteAsync(T entity, CancellationToken cancellationToken = default);

--- a/Domain/Interfaces/IBaseRepository.cs
+++ b/Domain/Interfaces/IBaseRepository.cs
@@ -1,10 +1,12 @@
-﻿namespace Domain.Interfaces
+﻿using System.Linq.Expressions;
+
+namespace Domain.Interfaces
 {
     namespace Domain.Interfaces
     {
         public interface IBaseRepository<T> where T : class
         {
-            Task<T?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+            Task<T?> GetByIdAsync(int id, CancellationToken cancellationToken = default, params Expression<Func<T, object>>[] includes);
             Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default);
             Task AddAsync(T entity, CancellationToken cancellationToken = default);
             Task UpdateAsync(T entity, CancellationToken cancellationToken = default);

--- a/Domain/Interfaces/IQuestMetadataRepository.cs
+++ b/Domain/Interfaces/IQuestMetadataRepository.cs
@@ -4,6 +4,6 @@ namespace Domain.Interfaces
 {
     public interface IQuestMetadataRepository
     {
-        Task<IEnumerable<QuestMetadata>> GetTodaysQuestsAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<QuestMetadata>> GetTodaysQuestsAsync(int accountId, CancellationToken cancellationToken = default);
     }
 }

--- a/Infrastructure/Repositories/Quests/QuestMetadataRepository.cs
+++ b/Infrastructure/Repositories/Quests/QuestMetadataRepository.cs
@@ -14,7 +14,7 @@ namespace Infrastructure.Repositories.Quests
             _context = context;
         }
 
-        public async Task<IEnumerable<QuestMetadata>> GetTodaysQuestsAsync(CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<QuestMetadata>> GetTodaysQuestsAsync(int accountId, CancellationToken cancellationToken = default)
         {
             DateTime today = DateTime.UtcNow.Date;
 
@@ -25,6 +25,7 @@ namespace Infrastructure.Repositories.Quests
                 .Include(q => q.MonthlyQuest)
                 .Include(q => q.SeasonalQuest)
                 .Where(q =>
+                    q.AccountId == accountId && (
                     (q.OneTimeQuest != null &&
                     (!q.OneTimeQuest.StartDate.HasValue || q.OneTimeQuest.StartDate.Value.Date <= today) &&
                     (!q.OneTimeQuest.EndDate.HasValue || q.OneTimeQuest.EndDate.Value.Date >= today)) ||
@@ -44,7 +45,7 @@ namespace Infrastructure.Repositories.Quests
                     (q.SeasonalQuest != null &&
                     (!q.SeasonalQuest.StartDate.HasValue || q.SeasonalQuest.StartDate.Value.Date <= today) &&
                     (!q.SeasonalQuest.EndDate.HasValue || q.SeasonalQuest.EndDate.Value.Date >= today))
-                    )
+                    ))
                 .AsNoTracking()
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/Tests/Services/OneTimeQuestServiceTests/GetByIdAsyncTests.cs
+++ b/Tests/Services/OneTimeQuestServiceTests/GetByIdAsyncTests.cs
@@ -40,7 +40,7 @@ namespace Tests.Services.OneTimeQuestServiceTests
                 .ReturnsAsync(expectedQuest);
 
             // Act: call the method being tested
-            var result = await _service.GetByIdAsync(1, CancellationToken.None);
+            var result = await _service.GetQuestByIdAsync(1, CancellationToken.None);
 
             // Assert: verify the output is as expected
             Assert.NotNull(result);
@@ -52,7 +52,7 @@ namespace Tests.Services.OneTimeQuestServiceTests
         public async Task GetByIdAsync_ShouldReturnNull_WhenQuestDoesNotExists()
         {
             // Act
-            var result = await _service.GetByIdAsync(2, CancellationToken.None);
+            var result = await _service.GetQuestByIdAsync(2, CancellationToken.None);
 
             // Assert
             Assert.Null(result);

--- a/Tests/Services/OneTimeQuestServiceTests/UpdateAsyncTests.cs
+++ b/Tests/Services/OneTimeQuestServiceTests/UpdateAsyncTests.cs
@@ -36,6 +36,7 @@ namespace Tests.Services.OneTimeQuestServiceTests
         {
             // Arrange
             var questId = 1;
+            var accountId = 1;
             var questBeforeUpdate = new OneTimeQuest { Id = questId, Title = "Before update", Description = "Should be null after update" };
             var updateValues = new UpdateOneTimeQuestDto { Title = "After update" };
 
@@ -49,7 +50,7 @@ namespace Tests.Services.OneTimeQuestServiceTests
                 .Verifiable();
 
             // Act
-            await _service.UpdateAsync(questId, updateValues, CancellationToken.None);
+            await _service.UpdateUserQuestAsync(questId, accountId, updateValues, CancellationToken.None);
 
             // Assert
             _repositoryMock.Verify(repo => repo.UpdateAsync(It.Is<OneTimeQuest>(


### PR DESCRIPTION
This pull request introduces significant changes to the authorization and validation processes across multiple controllers in the API. The most important changes include adding authorization checks to the controllers and ensuring that the account identifier from the JWT token is validated before performing any operations.

Authorization and validation improvements:

* [`Api/Controllers/AccountController.cs`](diffhunk://#diff-33359844e3053469fe742898d4aaf9c1836344c6c233991130eea6a196f74212R3-R12): Added `[Authorize]` attribute to the controller and validated the account identifier from the JWT token in `GetAccount` and `PatchAccount` methods. [[1]](diffhunk://#diff-33359844e3053469fe742898d4aaf9c1836344c6c233991130eea6a196f74212R3-R12) [[2]](diffhunk://#diff-33359844e3053469fe742898d4aaf9c1836344c6c233991130eea6a196f74212R35-R41) [[3]](diffhunk://#diff-33359844e3053469fe742898d4aaf9c1836344c6c233991130eea6a196f74212R61-R67)

* [`Api/Controllers/AllQuestsController.cs`](diffhunk://#diff-4d69ce2af9459d8e7c3aa2810eb68223cbd8f0cd853d8e2cfcff7ba334f38ef5R3-R12): Added `[Authorize]` attribute to the controller and validated the account identifier from the JWT token in `GetAllQuestesAsync` method. [[1]](diffhunk://#diff-4d69ce2af9459d8e7c3aa2810eb68223cbd8f0cd853d8e2cfcff7ba334f38ef5R3-R12) [[2]](diffhunk://#diff-4d69ce2af9459d8e7c3aa2810eb68223cbd8f0cd853d8e2cfcff7ba334f38ef5L21-R29)

* [`Api/Controllers/DailyQuestController.cs`](diffhunk://#diff-c30315ff6190643a368a040743112ede971267237ea989848d5bda883cdcb79aR5-R12): Added `[Authorize]` attribute to the controller, validated the account identifier from the JWT token, and updated method names to reflect user-specific operations. [[1]](diffhunk://#diff-c30315ff6190643a368a040743112ede971267237ea989848d5bda883cdcb79aR5-R12) [[2]](diffhunk://#diff-c30315ff6190643a368a040743112ede971267237ea989848d5bda883cdcb79aL21-R51) [[3]](diffhunk://#diff-c30315ff6190643a368a040743112ede971267237ea989848d5bda883cdcb79aL45-R67) [[4]](diffhunk://#diff-c30315ff6190643a368a040743112ede971267237ea989848d5bda883cdcb79aL59-L64) [[5]](diffhunk://#diff-c30315ff6190643a368a040743112ede971267237ea989848d5bda883cdcb79aL73-R106)

* [`Api/Controllers/MonthlyQuestController.cs`](diffhunk://#diff-98e08a5485480a9439a814ab3bbbe60a7a13de711a8639bff43148fbdcf4d008R5-R12): Added `[Authorize]` attribute to the controller, validated the account identifier from the JWT token, and updated method names to reflect user-specific operations. [[1]](diffhunk://#diff-98e08a5485480a9439a814ab3bbbe60a7a13de711a8639bff43148fbdcf4d008R5-R12) [[2]](diffhunk://#diff-98e08a5485480a9439a814ab3bbbe60a7a13de711a8639bff43148fbdcf4d008L21-R50) [[3]](diffhunk://#diff-98e08a5485480a9439a814ab3bbbe60a7a13de711a8639bff43148fbdcf4d008L45-R66) [[4]](diffhunk://#diff-98e08a5485480a9439a814ab3bbbe60a7a13de711a8639bff43148fbdcf4d008L59-R79) [[5]](diffhunk://#diff-98e08a5485480a9439a814ab3bbbe60a7a13de711a8639bff43148fbdcf4d008L73-R105)

* [`Api/Controllers/OneTimeQuestController.cs`](diffhunk://#diff-1e11720ca1e66cfd93994eecbcf6140b5962b6e810180dd54f53a222d081bc23R5-R52): Added `[Authorize]` attribute to the controller, validated the account identifier from the JWT token, and updated method names to reflect user-specific operations. [[1]](diffhunk://#diff-1e11720ca1e66cfd93994eecbcf6140b5962b6e810180dd54f53a222d081bc23R5-R52) [[2]](diffhunk://#diff-1e11720ca1e66cfd93994eecbcf6140b5962b6e810180dd54f53a222d081bc23L46-R107)