### PR TITLE
QuestService now properly handles time zones when fetching active quests

### DIFF
--- a/Domain/Interfaces/Quests/IQuestRepository.cs
+++ b/Domain/Interfaces/Quests/IQuestRepository.cs
@@ -5,7 +5,7 @@ namespace Domain.Interfaces.Quests
 {
     public interface IQuestRepository
     {
-        Task<IEnumerable<Quest>> GetActiveQuestsAsync(int accountId, SeasonEnum currentSeason, CancellationToken cancellationToken = default);
+        Task<IEnumerable<Quest>> GetActiveQuestsAsync(int accountId, DateTime todayStart, DateTime todayEnd, SeasonEnum currentSeason, CancellationToken cancellationToken = default);
         Task<IEnumerable<Quest>> GetQuestsByTypeAsync(int accountId, QuestTypeEnum questType, CancellationToken cancellationToken = default);
         Task<Quest?> GetQuestByIdAsync(int questId, QuestTypeEnum questType, CancellationToken cancellationToken = default);
         Task DeleteQuestByIdAsync(int questId, CancellationToken cancellationToken = default);

--- a/Infrastructure/Repositories/Quests/QuestRepository.cs
+++ b/Infrastructure/Repositories/Quests/QuestRepository.cs
@@ -21,35 +21,38 @@ namespace Infrastructure.Repositories.Quests
             _logger = logger;
         }
 
-        public async Task<IEnumerable<Quest>> GetActiveQuestsAsync(int accountId, SeasonEnum currentSeason, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<Quest>> GetActiveQuestsAsync(
+            int accountId,
+            DateTime todayStart,
+            DateTime todayEnd,
+            SeasonEnum currentSeason,
+            CancellationToken cancellationToken = default)
         {
-            DateTime today = DateTime.UtcNow.Date;
-
             var baseQuery = _context.Quests
                 .Where(q => q.AccountId == accountId)
                 .Where(q =>
                     (q.QuestType == QuestTypeEnum.OneTime &&
-                        (q.StartDate ?? DateTime.MinValue) <= today &&
-                        (q.EndDate ?? DateTime.MaxValue) >= today &&
+                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd &&
                         (q.StartDate.HasValue || q.EndDate.HasValue))
 
                     || (q.QuestType == QuestTypeEnum.Daily &&
-                        (q.StartDate ?? DateTime.MinValue) <= today &&
-                        (q.EndDate ?? DateTime.MaxValue) >= today)
+                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd)
 
                     || (q.QuestType == QuestTypeEnum.Weekly &&
-                        (q.StartDate ?? DateTime.MinValue) <= today &&
-                        (q.EndDate ?? DateTime.MaxValue) >= today &&
-                        (q.WeeklyQuest_Days.Any(wd => wd.Weekday == (WeekdayEnum)today.DayOfWeek)))
+                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd &&
+                        (q.WeeklyQuest_Days.Any(wd => wd.Weekday == (WeekdayEnum)todayStart.DayOfWeek)))
 
                     || (q.QuestType == QuestTypeEnum.Monthly &&
-                        (q.StartDate ?? DateTime.MinValue) <= today &&
-                        (q.EndDate ?? DateTime.MaxValue) >= today &&
-                        (q.MonthlyQuest_Days!.StartDay <= today.Day && q.MonthlyQuest_Days.EndDay >= today.Day))
+                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd &&
+                        (q.MonthlyQuest_Days!.StartDay <= todayStart.Day && q.MonthlyQuest_Days.EndDay >= todayEnd.Day))
 
                     || (q.QuestType == QuestTypeEnum.Seasonal &&
-                        (q.StartDate ?? DateTime.MinValue) <= today &&
-                        (q.EndDate ?? DateTime.MaxValue) >= today &&
+                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd &&
                         (q.SeasonalQuest_Season!.Season == currentSeason))
                 )
                 .Include(q => q.Quest_QuestLabels)


### PR DESCRIPTION
This pull request includes several changes to the `QuestService` and related repository classes to improve quest retrieval by incorporating user timezones and refining the date range logic. The most important changes include adding the `IAccountRepository` dependency, updating the `GetActiveQuestsAsync` method to use timezone-aware date ranges, and modifying the `IQuestRepository` and `QuestRepository` to support these changes.

### Dependency Injection and Initialization:

* [`Application/Services/Quests/QuestService.cs`](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R30): Added `IAccountRepository` dependency to the `QuestService` class and updated the constructor to initialize this new dependency. [[1]](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R30) [[2]](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6L37-R40) [[3]](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R49)

### Timezone and Date Range Handling:

* [`Application/Services/Quests/QuestService.cs`](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R131-R145): Updated the `GetActiveQuestsAsync` method to retrieve the user's timezone from the account repository, calculate the current local date range, and use this range to filter active quests.

### Repository Method Updates:

* [`Domain/Interfaces/Quests/IQuestRepository.cs`](diffhunk://#diff-10333a8e290dd519de7604863347b609c82f28e5737da5a3211f0bbd20047a12L8-R8): Modified the `GetActiveQuestsAsync` method signature to include `todayStart` and `todayEnd` parameters for date range filtering.
* [`Infrastructure/Repositories/Quests/QuestRepository.cs`](diffhunk://#diff-f5568ec40509c0bac53d847f6cb5f0b1466fee1b750859cbb43e4b81c006720dL24-R55): Updated the implementation of `GetActiveQuestsAsync` to use the provided `todayStart` and `todayEnd` parameters for filtering quests based on their start and end dates.

These changes ensure that quests are retrieved based on the user's local time, providing a more accurate and personalized experience.