### PR TITLE
Change password feature

### DIFF
--- a/Api/Controllers/AccountController.cs
+++ b/Api/Controllers/AccountController.cs
@@ -41,7 +41,7 @@ namespace Api.Controllers
             return Ok(account);
         }
 
-        [HttpPut("accounts/me")]
+        [HttpPatch("accounts/me")]
         public async Task<IActionResult> PatchAccount(
             UpdateAccountDto patchDto,
             CancellationToken cancellationToken = default)
@@ -58,6 +58,22 @@ namespace Api.Controllers
                 patchDto.Nickname = patchDto.Nickname.Trim();
 
             await _accountService.UpdateAccountAsync(accountId, patchDto, cancellationToken);
+            return NoContent();
+        }
+
+        [HttpPut("accounts/me/password")]
+        public async Task<IActionResult> ChangePassword(
+            ChangePasswordDto changePasswordDto,
+            CancellationToken cancellationToken = default)
+        {
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
+
+            changePasswordDto.OldPassword = changePasswordDto.OldPassword.Trim();
+            changePasswordDto.NewPassword = changePasswordDto.NewPassword.Trim();
+
+            await _accountService.ChangePasswordAsync(accountId, changePasswordDto, cancellationToken);
             return NoContent();
         }
     }

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -11,8 +11,8 @@ using Application.Interfaces.Quests;
 using Application.MappingProfiles;
 using Application.Services;
 using Application.Services.Quests;
-using Application.Validators;
 using Application.Validators.Accounts;
+using Application.Validators.Auth;
 using Application.Validators.QuestLabels;
 using Application.Validators.Quests;
 using Domain.Interfaces;
@@ -193,6 +193,7 @@ namespace Api
             builder.Services.AddValidatorsFromAssemblyContaining<LoginValidator>();
             builder.Services.AddValidatorsFromAssemblyContaining<CreateQuestLabelValidator>();
             builder.Services.AddValidatorsFromAssemblyContaining<PatchQuestLabelValidator>();
+            builder.Services.AddValidatorsFromAssemblyContaining<ChangePasswordValidator>();
             builder.Services.AddFluentValidationAutoValidation();
             builder.Services.AddFluentValidationClientsideAdapters();
 

--- a/Application/Dtos/Accounts/ChangePasswordDto.cs
+++ b/Application/Dtos/Accounts/ChangePasswordDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Application.Dtos.Accounts
+{
+    public class ChangePasswordDto
+    {
+        public string OldPassword { get; set; } = null!;
+        public string NewPassword { get; set; } = null!;
+    }
+}

--- a/Application/Interfaces/IAccountService.cs
+++ b/Application/Interfaces/IAccountService.cs
@@ -6,5 +6,6 @@ namespace Application.Interfaces
     {
         Task<GetAccountDto> GetAccountByIdAsync(int id, CancellationToken cancellationToken = default);
         Task UpdateAccountAsync(int accountId, UpdateAccountDto patchDto, CancellationToken cancellationToken = default);
+        Task ChangePasswordAsync(int accountId, ChangePasswordDto resetPasswordDto, CancellationToken cancellationToken = default);
     }
 }

--- a/Application/Services/AccountService.cs
+++ b/Application/Services/AccountService.cs
@@ -3,6 +3,8 @@ using Application.Interfaces;
 using AutoMapper;
 using Domain.Exceptions;
 using Domain.Interfaces;
+using Domain.Models;
+using Microsoft.AspNetCore.Identity;
 
 namespace Application.Services
 {
@@ -11,15 +13,18 @@ namespace Application.Services
         private readonly IAccountRepository _accountRepository;
         private readonly IMapper _mapper;
         private readonly IUserProfileRepository _userProfileRepository;
+        private readonly IPasswordHasher<Account> _passwordHasher;
 
         public AccountService(
             IAccountRepository accountRepository,
             IMapper mapper,
-            IUserProfileRepository userProfileRepository)
+            IUserProfileRepository userProfileRepository,
+            IPasswordHasher<Account> passwordHasher)
         {
             _accountRepository = accountRepository;
             _mapper = mapper;
             _userProfileRepository = userProfileRepository;
+            _passwordHasher = passwordHasher;
         }
 
         public async Task<GetAccountDto> GetAccountByIdAsync(int accountId, CancellationToken cancellationToken = default)
@@ -54,6 +59,20 @@ namespace Application.Services
             }
 
             _mapper.Map(patchDto, account);
+
+            await _accountRepository.UpdateAsync(account, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task ChangePasswordAsync(int accountId, ChangePasswordDto resetPasswordDto, CancellationToken cancellationToken = default)
+        {
+            var account = await _accountRepository.GetByIdAsync(accountId, cancellationToken).ConfigureAwait(false)
+                ?? throw new NotFoundException($"Account with ID: {accountId} not found");
+
+            var result = _passwordHasher.VerifyHashedPassword(account, account.HashPassword, resetPasswordDto.OldPassword);
+            if (result == PasswordVerificationResult.Failed)
+                throw new UnauthorizedException("Invalid password");
+
+            account.HashPassword = _passwordHasher.HashPassword(account, resetPasswordDto.NewPassword);
 
             await _accountRepository.UpdateAsync(account, cancellationToken).ConfigureAwait(false);
         }

--- a/Application/Validators/Accounts/ChangePasswordValidator.cs
+++ b/Application/Validators/Accounts/ChangePasswordValidator.cs
@@ -1,0 +1,27 @@
+﻿using Application.Dtos.Accounts;
+using FluentValidation;
+
+namespace Application.Validators.Accounts
+{
+    public class ChangePasswordValidator : AbstractValidator<ChangePasswordDto>
+    {
+        public ChangePasswordValidator()
+        {
+            RuleFor(x => x.OldPassword)
+                .NotEmpty().WithMessage("{PropertyName} is required")
+                .MinimumLength(6).WithMessage("{PropertyName} must be at least {MinLength} characters long.")
+                .MaximumLength(50).WithMessage("{PropertyName} must not exceed {MaxLength} characters.")
+                .Matches("^[a-zA-Z0-9_#@!-]*$")
+                .WithMessage("{PropertyName} must contain only letters, numbers, and the following special characters: _ @ # -");
+
+            RuleFor(x => x.NewPassword)
+                .NotEmpty().WithMessage("{PropertyName} is required")
+                .MinimumLength(6).WithMessage("{PropertyName} must be at least {MinLength} characters long.")
+                .MaximumLength(50).WithMessage("{PropertyName} must not exceed {MaxLength} characters.")
+                .Matches("^[a-zA-Z0-9_#@!-]*$")
+                .WithMessage("{PropertyName} must contain only letters, numbers, and the following special characters: _ @ # -")
+                .NotEqual(x => x.OldPassword)
+                .WithMessage("New password must be different from the old password.");
+        }
+    }
+}

--- a/Application/Validators/Auth/LoginValidator.cs
+++ b/Application/Validators/Auth/LoginValidator.cs
@@ -2,7 +2,7 @@
 using Application.Validators.Helpers;
 using FluentValidation;
 
-namespace Application.Validators
+namespace Application.Validators.Auth
 {
     public class LoginValidator : AbstractValidator<LoginDto>
     {

--- a/Tests/Factories/AccountFactory.cs
+++ b/Tests/Factories/AccountFactory.cs
@@ -4,23 +4,23 @@ namespace Tests.Factories
 {
     public static class AccountFactory
     {
-        public static Account CreateAccount(int accountId, string hashPassword, string email, string TimeZone)
+        public static Account CreateAccount(int accountId, string email, string? initialHashedPassword = null, string TimeZone = "Etc/UTC")
         {
-            return new Account(accountId, hashPassword, email, TimeZone)
+            return new Account
             {
                 Id = accountId,
-                HashPassword = hashPassword,
+                HashPassword = initialHashedPassword ?? $"hashed_password_for_{accountId}",
                 Email = email,
                 TimeZone = TimeZone
             };
         }
 
-        public static Account CreateAccountWithProfile(int accountId, string hashPassword, string email, string timeZone)
+        public static Account CreateAccountWithProfile(int accountId, string email, string? initialHashedPassword = null, string timeZone = "Etc/UTC")
         {
-            return new Account(accountId, hashPassword, email, timeZone)
+            return new Account
             {
                 Id = accountId,
-                HashPassword = hashPassword,
+                HashPassword = initialHashedPassword ?? $"hashed_password_for_{accountId}",
                 Email = email,
                 TimeZone = timeZone,
                 Profile = new UserProfile


### PR DESCRIPTION
This pull request introduces a new feature for changing user passwords and includes several related changes across multiple files. The most important changes include adding a new API endpoint for password change, implementing the password change functionality in the service layer, and updating the relevant tests and validators.

### New API Endpoint:
* [`Api/Controllers/AccountController.cs`](diffhunk://#diff-33359844e3053469fe742898d4aaf9c1836344c6c233991130eea6a196f74212R63-R78): Added a new `ChangePassword` endpoint using the `HttpPut` method to handle password change requests.

### Service Layer Updates:
* [`Application/Interfaces/IAccountService.cs`](diffhunk://#diff-026a64fc5c22800f02e24d69d96450664f97aef40417481e61acf86bf4bced41R9): Added a new method `ChangePasswordAsync` to the `IAccountService` interface.
* [`Application/Services/AccountService.cs`](diffhunk://#diff-29d1393e188351ef0ffe88de6e1f24f2ef7bf57115175964fd66a05aaaf374b4R65-R78): Implemented the `ChangePasswordAsync` method in the `AccountService` class, including password verification and hashing.

### Data Transfer Object (DTO):
* [`Application/Dtos/Accounts/ChangePasswordDto.cs`](diffhunk://#diff-327367a1ea218c2770886417395d46f6a5ecd5e4608c2101925a50274220b6eaR1-R8): Created a new `ChangePasswordDto` class to represent the data required for changing a password.

### Validators:
* [`Application/Validators/Accounts/ChangePasswordValidator.cs`](diffhunk://#diff-615077c35d9212b51f127bb4f33fa43ee2d746dd65908d45a6253e92321026beR1-R27): Added a new validator `ChangePasswordValidator` to ensure the new password meets the required criteria and is different from the old password.
* [`Api/Program.cs`](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR196): Registered the new `ChangePasswordValidator` with the dependency injection container.

### Tests:
* [`Tests/Services/AccountServiceTests.cs`](diffhunk://#diff-d6d125b72b55f3118362f7e011d31c33d9e7ed54de1cc0b55dc0d7c1e2547155R252-R359): Added new unit tests for the `ChangePasswordAsync` method to cover scenarios such as successful password change, invalid old password, and non-existent account.