### PR TITLE
Added logic for incrementing number of total and completed quests

### DIFF
--- a/Application/Dtos/Quests/BaseQuestCompletionPatchDto.cs
+++ b/Application/Dtos/Quests/BaseQuestCompletionPatchDto.cs
@@ -6,6 +6,6 @@ namespace Application.Dtos.Quests
     {
         [JsonIgnore]
         public int Id { get; set; }
-        public bool? IsCompleted { get; set; }
+        public bool IsCompleted { get; set; }
     }
 }

--- a/Application/MappingProfiles/DailyQuestProfile.cs
+++ b/Application/MappingProfiles/DailyQuestProfile.cs
@@ -34,7 +34,6 @@ namespace Application.MappingProfiles
 
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<DailyQuestCompletionPatchDto, Quest>()
-                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/MonthlyQuestProfile.cs
+++ b/Application/MappingProfiles/MonthlyQuestProfile.cs
@@ -41,7 +41,6 @@ namespace Application.MappingProfiles
 
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<MonthlyQuestCompletionPatchDto, Quest>()
-                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/OneTimeQuestProfile.cs
+++ b/Application/MappingProfiles/OneTimeQuestProfile.cs
@@ -34,7 +34,6 @@ namespace Application.MappingProfiles
 
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<OneTimeQuestCompletionDto, Quest>()
-                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/SeasonalQuestProfile.cs
+++ b/Application/MappingProfiles/SeasonalQuestProfile.cs
@@ -38,7 +38,6 @@ namespace Application.MappingProfiles
 
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<SeasonalQuestCompletionPatchDto, Quest>()
-                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/WeeklyQuestProfile.cs
+++ b/Application/MappingProfiles/WeeklyQuestProfile.cs
@@ -39,7 +39,6 @@ namespace Application.MappingProfiles
 
             // Patch DTO -> Entity (Convert String -> Enum, Ignore Nulls)
             CreateMap<WeeklyQuestCompletionPatchDto, Quest>()
-                .ForMember(dest => dest.IsCompleted, opt => opt.MapFrom((src, dest) => src.IsCompleted ?? dest.IsCompleted))
                 .ForAllMembers(opt => opt.Condition((src, dest, srcMember) => srcMember != null));
 
             // Update DTO -> Entity (Convert String -> Enum)

--- a/Domain/Interfaces/IUserProfileRepository.cs
+++ b/Domain/Interfaces/IUserProfileRepository.cs
@@ -1,7 +1,11 @@
-﻿namespace Domain.Interfaces
+﻿using Domain.Models;
+
+namespace Domain.Interfaces
 {
     public interface IUserProfileRepository
     {
+        Task<UserProfile?> GetByAccountIdAsync(int accountId, CancellationToken cancellationToken = default);
         Task<bool> ExistsByNicknameAsync(string nickname, CancellationToken cancellationToken = default);
+        Task UpdateAsync(UserProfile userProfile, CancellationToken cancellationToken = default);
     }
 }

--- a/Infrastructure/Repositories/Quests/QuestRepository.cs
+++ b/Infrastructure/Repositories/Quests/QuestRepository.cs
@@ -190,7 +190,29 @@ namespace Infrastructure.Repositories.Quests
                     Email = q.Account.Email,
                     TimeZone = q.Account.TimeZone,
                     CreatedAt = q.Account.CreatedAt,
-                    UpdatedAt = q.Account.UpdatedAt
+                    UpdatedAt = q.Account.UpdatedAt,
+                    Profile = new UserProfile
+                    {
+                        Id = q.Account.Profile.Id,
+                        AccountId = q.AccountId,
+                        TotalQuests = q.Account.Profile.TotalQuests,
+                        CompletedQuests = q.Account.Profile.CompletedQuests,
+                        TotalExperience = q.Account.Profile.TotalExperience,
+                        CurrentExperience = q.Account.Profile.CurrentExperience,
+                        CreatedAt = q.Account.Profile.CreatedAt,
+                        UpdatedAt = q.Account.Profile.UpdatedAt,
+                        UserProfile_Badges = q.Account.Profile.UserProfile_Badges.Select(upb => new UserProfile_Badge
+                        {
+                            BadgeId = upb.BadgeId,
+                            UserProfileId = upb.UserProfileId,
+                            EarnedAt = upb.EarnedAt,
+                            Badge = new Badge
+                            {
+                                Id = upb.Badge.Id,
+                                Text = upb.Badge.Text
+                            }
+                        }).ToList()
+                    }
                 },
                 QuestType = q.QuestType,
                 Title = q.Title,

--- a/Infrastructure/Repositories/UserProfileRepository.cs
+++ b/Infrastructure/Repositories/UserProfileRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Domain.Interfaces;
+using Domain.Models;
 using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,6 +18,19 @@ namespace Infrastructure.Repositories
         {
             return await _context.UserProfiles.AnyAsync(u => u.Nickname == nickname, cancellationToken)
                 .ConfigureAwait(false);
+        }
+
+        public async Task<UserProfile?> GetByAccountIdAsync(int accountId, CancellationToken cancellationToken = default)
+        {
+            return await _context.UserProfiles
+                .FirstOrDefaultAsync(u => u.AccountId == accountId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public async Task UpdateAsync(UserProfile userProfile, CancellationToken cancellationToken = default)
+        {
+            _context.UserProfiles.Update(userProfile);
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Closes: #62 

This pull request introduces several changes to the quest completion and user profile tracking mechanisms in the application. The key changes include modifying the `BaseQuestCompletionPatchDto` class, updating mapping profiles, enhancing the `QuestService` class, and adding methods to the `IUserProfileRepository` interface and its implementation.

### Quest Completion and User Profile Tracking Enhancements:

* **BaseQuestCompletionPatchDto Update:**
  * Changed the `IsCompleted` property from nullable to non-nullable in `BaseQuestCompletionPatchDto` (`Application/Dtos/Quests/BaseQuestCompletionPatchDto.cs`).

* **Mapping Profile Adjustments:**
  * Removed the conditional mapping of `IsCompleted` in `DailyQuestProfile`, `MonthlyQuestProfile`, `OneTimeQuestProfile`, `SeasonalQuestProfile`, and `WeeklyQuestProfile` (`Application/MappingProfiles/*`). [[1]](diffhunk://#diff-af12359dc8d8b20362c579652c1c2cf1ef64eb2f6ac3f0f4483b329682f1e2c5L37) [[2]](diffhunk://#diff-aef632f45b79b85d95c8da32ed1a0fd2d4fc9ab36be4b9354a1852adb94cf3b7L44) [[3]](diffhunk://#diff-4cbc2deb25a4def433891278da12248265da37cff7904fd660138ab3cc843d76L37) [[4]](diffhunk://#diff-4e4966ee458d7d1775ca380f1a8d37e48dea0a6c74c8c47f575e45b52753cdb0L41) [[5]](diffhunk://#diff-d4ac458cadee8cea7cefbfa9f06c9031c3e5c0c26d0957835fb7499cef050876L42)

* **QuestService Enhancements:**
  * Added `IUserProfileRepository` to `QuestService` and updated the constructor and methods to handle user profile updates (`Application/Services/Quests/QuestService.cs`). [[1]](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R31) [[2]](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6L40-R42) [[3]](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R52)
  * Enhanced `CreateUserQuestAsync` to increment the total quests count in the user profile (`Application/Services/Quests/QuestService.cs`).
  * Improved `UpdateQuestCompletionAsync` to check user timezone and increment completed quests count in the user profile (`Application/Services/Quests/QuestService.cs`). [[1]](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6L115-R163) [[2]](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R172-R181)
  * Refined `GetActiveQuestsAsync` to handle timezone conversion more clearly (`Application/Services/Quests/QuestService.cs`).

* **UserProfileRepository Interface and Implementation:**
  * Added methods to get and update user profiles by account ID in `IUserProfileRepository` and its implementation (`Domain/Interfaces/IUserProfileRepository.cs`, `Infrastructure/Repositories/UserProfileRepository.cs`). [[1]](diffhunk://#diff-60fad3ce9bd1bd777f570ada7ac631ee6e55801b3945c766359b05c1fc852c53L1-R9) [[2]](diffhunk://#diff-d934fa4ad97057015772cb614e1b14b0b7faba8a9fb4eae529560e69b21c11b2R2) [[3]](diffhunk://#diff-d934fa4ad97057015772cb614e1b14b0b7faba8a9fb4eae529560e69b21c11b2R22-R34)

These changes aim to improve the accuracy and efficiency of quest completion tracking and user profile management within the application.