### PR TITLE
Changed PATCH to PUT on account update endpoint

### DIFF
--- a/Api/Controllers/AccountController.cs
+++ b/Api/Controllers/AccountController.cs
@@ -41,8 +41,8 @@ namespace Api.Controllers
             return Ok(account);
         }
 
-        [HttpPatch("accounts/me")]
-        public async Task<IActionResult> PatchAccount(
+        [HttpPut("accounts/me")]
+        public async Task<IActionResult> UpdateAccount(
             UpdateAccountDto patchDto,
             CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
This pull request includes a change to the `Api/Controllers/AccountController.cs` file to update the HTTP method and endpoint name for the account update functionality.

Changes to account update functionality:

* [`Api/Controllers/AccountController.cs`](diffhunk://#diff-33359844e3053469fe742898d4aaf9c1836344c6c233991130eea6a196f74212L44-R45): Changed the HTTP method from `PATCH` to `PUT` and renamed the endpoint method from `PatchAccount` to `UpdateAccount`.