### PR TITLE
Added endpoint to delete account

### DIFF
--- a/Api/Controllers/AccountController.cs
+++ b/Api/Controllers/AccountController.cs
@@ -66,5 +66,17 @@ namespace Api.Controllers
             await _accountService.ChangePasswordAsync(accountId, changePasswordDto, cancellationToken);
             return NoContent();
         }
+
+        [HttpDelete("accounts/me")]
+        public async Task<IActionResult> DeleteAccount(
+            DeleteAccountDto deleteAccountDto,
+            CancellationToken cancellationToken = default)
+        {
+            var accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
+            await _accountService.DeleteAccountAsync(accountId, deleteAccountDto, cancellationToken);
+            return NoContent();
+        }
     }
 }

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -195,6 +195,7 @@ namespace Api
             builder.Services.AddValidatorsFromAssemblyContaining<CreateQuestLabelValidator>();
             builder.Services.AddValidatorsFromAssemblyContaining<PatchQuestLabelValidator>();
             builder.Services.AddValidatorsFromAssemblyContaining<ChangePasswordValidator>();
+            builder.Services.AddValidatorsFromAssemblyContaining<DeleteAccountValidator>();
             builder.Services.AddFluentValidationAutoValidation();
             builder.Services.AddFluentValidationClientsideAdapters();
 

--- a/Application/Dtos/Accounts/DeleteAccountDto.cs
+++ b/Application/Dtos/Accounts/DeleteAccountDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Dtos.Accounts
+{
+    public class DeleteAccountDto
+    {
+        public string Password { get; set; } = null!;
+    }
+}

--- a/Application/Interfaces/IAccountService.cs
+++ b/Application/Interfaces/IAccountService.cs
@@ -7,5 +7,6 @@ namespace Application.Interfaces
         Task<GetAccountDto> GetAccountByIdAsync(int id, CancellationToken cancellationToken = default);
         Task UpdateAccountAsync(int accountId, UpdateAccountDto patchDto, CancellationToken cancellationToken = default);
         Task ChangePasswordAsync(int accountId, ChangePasswordDto resetPasswordDto, CancellationToken cancellationToken = default);
+        Task DeleteAccountAsync(int accountId, DeleteAccountDto deleteAccountDto, CancellationToken cancellationToken = default);
     }
 }

--- a/Application/Validators/Accounts/DeleteAccountValidator.cs
+++ b/Application/Validators/Accounts/DeleteAccountValidator.cs
@@ -1,0 +1,18 @@
+﻿using Application.Dtos.Accounts;
+using FluentValidation;
+
+namespace Application.Validators.Accounts
+{
+    public class DeleteAccountValidator : AbstractValidator<DeleteAccountDto>
+    {
+        public DeleteAccountValidator()
+        {
+            RuleFor(x => x.Password)
+                .NotEmpty().WithMessage("{PropertyName} is required")
+                .MinimumLength(6).WithMessage("{PropertyName} must be at least {MinLength} characters long.")
+                .MaximumLength(50).WithMessage("{PropertyName} must not exceed {MaxLength} characters.")
+                .Matches("^[a-zA-Z0-9_#@!-]*$")
+                .WithMessage("{PropertyName} must contain only letters, numbers, and the following special characters: _ @ # -");
+        }
+    }
+}

--- a/Domain/Interfaces/IQuestLabelRepository.cs
+++ b/Domain/Interfaces/IQuestLabelRepository.cs
@@ -11,5 +11,6 @@ namespace Domain.Interfaces
         Task DeleteLabelAsync(QuestLabel label, CancellationToken cancellationToken = default);
         Task<QuestLabel?> GetLabelByValueAsync(string value, int accountId, CancellationToken cancellationToken = default);
         Task<bool> IsLabelOwnedByUserAsync(int labelId, int accountId, CancellationToken cancellationToken = default);
+        Task DeleteQuestLabelsByAccountIdAsync(int accountId, CancellationToken cancellationToken = default);
     }
 }

--- a/Infrastructure/Repositories/QuestLabelRepository.cs
+++ b/Infrastructure/Repositories/QuestLabelRepository.cs
@@ -60,5 +60,19 @@ namespace Infrastructure.Repositories
                 .AnyAsync(ql => ql.Id == labelId && ql.AccountId == accountId, cancellationToken)
                 .ConfigureAwait(false);
         }
+
+        public async Task DeleteQuestLabelsByAccountIdAsync(int accountId, CancellationToken cancellationToken = default)
+        {
+            var questLabelsToDelete = await _context.QuestLabels
+                .Where(ql => ql.AccountId == accountId)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (questLabelsToDelete.Count != 0)
+            {
+                _context.QuestLabels.RemoveRange(questLabelsToDelete);
+                await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/Tests/Factories/QuestLabelFactory.cs
+++ b/Tests/Factories/QuestLabelFactory.cs
@@ -1,0 +1,22 @@
+﻿using Domain.Models;
+
+namespace Tests.Factories
+{
+    public static class QuestLabelFactory
+    {
+        public static QuestLabel CreateQuestLabel(
+            int id = 1,
+            int accountId = 1,
+            string text = "text")
+        {
+            return new QuestLabel
+            {
+                Id = id,
+                AccountId = accountId,
+                Value = text,
+                BackgroundColor = "backgroundColor",
+                TextColor = "textColor"
+            };
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to allow users to delete their accounts. The changes include adding a new endpoint, creating a corresponding DTO and validator, updating the account service, and adding tests for the new functionality.

### New Feature: Account Deletion

* [`Api/Controllers/AccountController.cs`](diffhunk://#diff-33359844e3053469fe742898d4aaf9c1836344c6c233991130eea6a196f74212R69-R80): Added a new endpoint `DeleteAccount` to handle account deletion requests.
* [`Application/Dtos/Accounts/DeleteAccountDto.cs`](diffhunk://#diff-d2a2f2be5ea40baba5fbcfabef1b0faaf4f392f43fb379c5131a825f8ae8c373R1-R7): Created a new DTO `DeleteAccountDto` to capture the password required for account deletion.
* [`Application/Validators/Accounts/DeleteAccountValidator.cs`](diffhunk://#diff-3b80e688c3c12fa59cb6b76c07c6fd002cfbd5bb6e8d3d589a096291a4ede86cR1-R18): Added a validator for `DeleteAccountDto` to ensure the password is provided and meets specific criteria.
* [`Application/Interfaces/IAccountService.cs`](diffhunk://#diff-026a64fc5c22800f02e24d69d96450664f97aef40417481e61acf86bf4bced41R10): Updated the `IAccountService` interface to include a new method `DeleteAccountAsync`.
* [`Application/Services/AccountService.cs`](diffhunk://#diff-29d1393e188351ef0ffe88de6e1f24f2ef7bf57115175964fd66a05aaaf374b4R82-R94): Implemented the `DeleteAccountAsync` method to handle the deletion of the account and associated quest labels.

### Dependency Injection and Repository Updates

* [`Api/Program.cs`](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR198): Registered the `DeleteAccountValidator` with the service container.
* [`Domain/Interfaces/IQuestLabelRepository.cs`](diffhunk://#diff-7af386553937faa7c521961b15e471496b550c77e1da8bb69e38eb93ec7e3041R14): Added a new method `DeleteQuestLabelsByAccountIdAsync` to handle the deletion of quest labels associated with an account.
* [`Infrastructure/Repositories/QuestLabelRepository.cs`](diffhunk://#diff-a22de96e2ecac6cd165ad174f35c0d2081a7b240af03e8e92763250bf3639bc4R63-R76): Implemented the `DeleteQuestLabelsByAccountIdAsync` method.

### Testing

* [`Tests/Services/AccountServiceTests.cs`](diffhunk://#diff-d6d125b72b55f3118362f7e011d31c33d9e7ed54de1cc0b55dc0d7c1e2547155R362-R434): Added unit tests for the `DeleteAccountAsync` method to ensure it behaves correctly when the password is invalid and when the account and quest labels are successfully deleted.
* [`Tests/Factories/QuestLabelFactory.cs`](diffhunk://#diff-eccc3f52e0df4a41f21162f1659a83ece36888741e470d4fa1dc82f694e5c5c1R1-R22): Created a factory for generating quest label test data.