### PR TITLE
Refactored leveling system for user profiles

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -4,6 +4,7 @@ using Api.Converters;
 using Api.Filters;
 using Api.Middlewares;
 using Application.Configurations;
+using Application.Configurations.Leveling;
 using Application.Dtos.Quests;
 using Application.Helpers;
 using Application.Interfaces;
@@ -184,6 +185,7 @@ namespace Api
             builder.Services.AddScoped<IQuestWeekdaysHandler, QuestWeekdaysHandler>();
             builder.Services.AddScoped<ITokenGenerator, TokenGenerator>();
             builder.Services.AddScoped<ITokenValidator, TokenValidator>();
+            builder.Services.AddSingleton<ILevelingService, LevelingService>();
 
             // Register Validators
             builder.Services.AddValidatorsFromAssemblyContaining<BaseCreateQuestValidator<BaseCreateQuestDto>>();
@@ -200,16 +202,7 @@ namespace Api
             builder.Services.AddFluentValidationClientsideAdapters();
 
             // Register AutoMapper profiles
-            builder.Services.AddAutoMapper(cfg =>
-            {
-                cfg.AddProfile<OneTimeQuestProfile>();
-                cfg.AddProfile<DailyQuestProfile>();
-                cfg.AddProfile<WeeklyQuestProfile>();
-                cfg.AddProfile<MonthlyQuestProfile>();
-                cfg.AddProfile<SeasonalQuestProfile>();
-                cfg.AddProfile<AccountProfile>();
-                cfg.AddProfile<QuestLabelProfile>();
-            });
+            builder.Services.AddAutoMapper(typeof(AccountProfile).Assembly); // Automatically register all profiles in the assembly
 
             // Configure EF Core with SQL Server
             builder.Services.AddDbContext<AppDbContext>(options =>
@@ -227,6 +220,7 @@ namespace Api
 
             // Register configurations
             builder.Services.Configure<JwtSettings>(builder.Configuration.GetSection("Jwt"));
+            builder.Services.Configure<LevelingOptions>(builder.Configuration.GetSection(LevelingOptions.SectionName));
 
             // Configure Authentication
             builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme) // Default is not necessary since we use only one scheme

--- a/Api/appsettings.json
+++ b/Api/appsettings.json
@@ -22,5 +22,50 @@
     }
   },
   "AllowedHosts": "*",
-  "SeedData": false
+  "SeedData": false,
+  "Leveling": {
+    "MaxLevel": 10,
+    "Curve": [
+      {
+        "Level": 1,
+        "RequiredTotalXp": 0
+      },
+      {
+        "Level": 2,
+        "RequiredTotalXp": 100
+      },
+      {
+        "Level": 3,
+        "RequiredTotalXp": 300
+      },
+      {
+        "Level": 4,
+        "RequiredTotalXp": 600
+      },
+      {
+        "Level": 5,
+        "RequiredTotalXp": 1000
+      },
+      {
+        "Level": 6,
+        "RequiredTotalXp": 1500
+      },
+      {
+        "Level": 7,
+        "RequiredTotalXp": 2100
+      },
+      {
+        "Level": 8,
+        "RequiredTotalXp": 2800
+      },
+      {
+        "Level": 9,
+        "RequiredTotalXp": 3600
+      },
+      {
+        "Level": 10,
+        "RequiredTotalXp": 4500
+      }
+    ]
+  }
 }

--- a/Application/Configurations/Leveling/LevelingOptions.cs
+++ b/Application/Configurations/Leveling/LevelingOptions.cs
@@ -1,0 +1,16 @@
+﻿namespace Application.Configurations.Leveling
+{
+    public class LevelingOptions
+    {
+        public const string SectionName = "Leveling";
+
+        public int MaxLevel { get; set; } = 10;
+        public List<LevelDefinition> Curve { get; set; } = [];
+    }
+
+    public class LevelDefinition
+    {
+        public int Level { get; set; }
+        public int RequiredTotalXp { get; set; }
+    }
+}

--- a/Application/Dtos/Accounts/GetAccountDto.cs
+++ b/Application/Dtos/Accounts/GetAccountDto.cs
@@ -8,9 +8,10 @@
         public string? Avatar { get; set; }
         public int CompletedQuests { get; set; }
         public int TotalQuests { get; set; }
-        public int Level { get; set; }
-        public int Xp { get; set; }
-        public int TotalXP { get; set; }
+        public int Level { get; set; } // Current user Level
+        public int UserXp { get; set; } // User's total accumulated XP
+        public int NextLevelTotalXpRequired { get; set; } // XP required to reach next level
+        public bool IsMaxLevel { get; set; } // Indicates if the user is at max level
         public string? Bio { get; set; }
         public DateTime JoinDate { get; set; }
         public ICollection<GetBadgeDto> Badges { get; set; } = [];

--- a/Application/Interfaces/ILevelingService.cs
+++ b/Application/Interfaces/ILevelingService.cs
@@ -1,0 +1,9 @@
+﻿using Application.Models;
+
+namespace Application.Interfaces
+{
+    public interface ILevelingService
+    {
+        LevelInfo CalculateLevelInfo(int totalXp);
+    }
+}

--- a/Application/MappingActions/SetUserLevelAction.cs
+++ b/Application/MappingActions/SetUserLevelAction.cs
@@ -1,0 +1,33 @@
+﻿using Application.Dtos.Accounts;
+using Application.Interfaces;
+using Application.Models;
+using AutoMapper;
+using Domain.Models;
+
+namespace Application.MappingActions
+{
+    public class SetUserLevelAction : IMappingAction<Account, GetAccountDto>
+    {
+        private readonly ILevelingService _levelingService;
+        public SetUserLevelAction(ILevelingService levelingService)
+        {
+            _levelingService = levelingService;
+        }
+        public void Process(Account source, GetAccountDto destination, ResolutionContext context)
+        {
+            if (source.Profile != null)
+            {
+                LevelInfo levelInfo = _levelingService.CalculateLevelInfo(source.Profile.TotalXp);
+
+                destination.Level = levelInfo.CurrentLevel;
+                destination.UserXp = source.Profile.TotalXp;
+                destination.IsMaxLevel = levelInfo.IsMaxLevel;
+
+                if (levelInfo.IsMaxLevel)
+                    destination.NextLevelTotalXpRequired = levelInfo.CurrentLevelRequiredXp;
+                else
+                    destination.NextLevelTotalXpRequired = levelInfo.NextLevelRequiredXp ?? levelInfo.CurrentLevelRequiredXp; // fallback to current level if next level is null
+            }
+        }
+    }
+}

--- a/Application/MappingProfiles/AccountProfile.cs
+++ b/Application/MappingProfiles/AccountProfile.cs
@@ -1,4 +1,5 @@
 ﻿using Application.Dtos.Accounts;
+using Application.MappingActions;
 using AutoMapper;
 using Domain.Models;
 
@@ -10,16 +11,17 @@ namespace Application.MappingProfiles
         {
             // Entity -> DTO
             CreateMap<Account, GetAccountDto>()
+                .ForMember(dest => dest.JoinDate, opt => opt.MapFrom(src => src.CreatedAt))
+                // Map from the Profile entity
                 .ForMember(dest => dest.Nickname, opt => opt.MapFrom(src => src.Profile.Nickname))
                 .ForMember(dest => dest.Avatar, opt => opt.MapFrom(src => src.Profile.Avatar))
                 .ForMember(dest => dest.CompletedQuests, opt => opt.MapFrom(src => src.Profile.CompletedQuests))
                 .ForMember(dest => dest.TotalQuests, opt => opt.MapFrom(src => src.Profile.TotalQuests))
-                .ForMember(dest => dest.Level, opt => opt.MapFrom(src => src.Profile.UserLevel))
-                .ForMember(dest => dest.Xp, opt => opt.MapFrom(src => src.Profile.CurrentExperience))
-                .ForMember(dest => dest.TotalXP, opt => opt.MapFrom(src => src.Profile.TotalExperience))
                 .ForMember(dest => dest.Bio, opt => opt.MapFrom(src => src.Profile.Bio))
-                .ForMember(dest => dest.JoinDate, opt => opt.MapFrom(src => src.CreatedAt))
-                .ForMember(dest => dest.Badges, opt => opt.MapFrom(src => src.Profile.UserProfile_Badges));
+                .ForMember(dest => dest.UserXp, opt => opt.MapFrom(src => src.Profile.TotalXp))
+                .ForMember(dest => dest.Badges, opt => opt.MapFrom(src => src.Profile.UserProfile_Badges))
+                // Calculate and Map Leveling Info
+                .AfterMap<SetUserLevelAction>();
 
             // Create DTO -> Entity
             CreateMap<CreateAccountDto, Account>()

--- a/Application/Models/LevelInfo.cs
+++ b/Application/Models/LevelInfo.cs
@@ -1,0 +1,10 @@
+﻿namespace Application.Models
+{
+    public record LevelInfo
+    {
+        public int CurrentLevel { get; init; }
+        public int CurrentLevelRequiredXp { get; init; } // Total XP required to reach the current level
+        public int? NextLevelRequiredXp { get; init; } // Total XP required to reach the next level (null if max level)
+        public bool IsMaxLevel { get; init; }
+    }
+}

--- a/Application/Services/LevelingService.cs
+++ b/Application/Services/LevelingService.cs
@@ -1,0 +1,46 @@
+﻿using Application.Configurations.Leveling;
+using Application.Interfaces;
+using Application.Models;
+using Domain.Exceptions;
+using Microsoft.Extensions.Options;
+
+namespace Application.Services
+{
+    public class LevelingService : ILevelingService
+    {
+        private readonly LevelingOptions _options;
+        private readonly List<LevelDefinition> _sortedCurve; // Cache sorted curve
+
+        public LevelingService(IOptions<LevelingOptions> options)
+        {
+            _options = options.Value;
+
+            if (_options.Curve == null || _options.Curve.Count == 0)
+                throw new InvalidArgumentException("Leveling curve configuration in missing or empty");
+
+            _sortedCurve = _options.Curve.OrderBy(l => l.Level).ToList();
+        }
+
+        public LevelInfo CalculateLevelInfo(int totalXp)
+        {
+            LevelDefinition currentLevelDef = _sortedCurve
+                .LastOrDefault(l => totalXp >= l.RequiredTotalXp)
+                ?? _sortedCurve.First();
+
+            int currentLevelNumber = currentLevelDef.Level;
+            bool isMaxLevel = currentLevelNumber >= _options.MaxLevel || currentLevelNumber >= _sortedCurve.Last().Level;
+
+            LevelDefinition? nextLevelDef = null;
+            if (!isMaxLevel)
+                nextLevelDef = _sortedCurve.FirstOrDefault(l => l.Level == currentLevelNumber + 1);
+
+            return new LevelInfo
+            {
+                CurrentLevel = currentLevelNumber,
+                CurrentLevelRequiredXp = currentLevelDef.RequiredTotalXp,
+                NextLevelRequiredXp = nextLevelDef?.RequiredTotalXp, // Null if max level or next level not defined
+                IsMaxLevel = isMaxLevel || nextLevelDef == null
+            };
+        }
+    }
+}

--- a/Application/Services/Quests/QuestService.cs
+++ b/Application/Services/Quests/QuestService.cs
@@ -172,12 +172,15 @@ namespace Application.Services.Quests
 
             if (shouldIncrementCount)
             {
+                int xpGained = 10;
                 var userProfile = await _userProfileRepository.GetByAccountIdAsync(existingQuest.AccountId, cancellationToken).ConfigureAwait(false)
                     ?? throw new NotFoundException($"User profile with account ID: {existingQuest.AccountId} not found");
 
                 userProfile.CompletedQuests++;
+                userProfile.TotalXp += xpGained;
+
                 await _userProfileRepository.UpdateAsync(userProfile, cancellationToken).ConfigureAwait(false);
-                _logger.LogInformation("Incremented CompletedQuests count for Account {AccountId}", existingQuest.AccountId);
+                _logger.LogInformation("Incremented CompletedQuests count and added {XpGained} XP for Account {AccountId}", xpGained, existingQuest.AccountId);
             }
         }
 

--- a/Domain/Models/UserProfile.cs
+++ b/Domain/Models/UserProfile.cs
@@ -8,12 +8,10 @@ namespace Domain.Models
         public int AccountId { get; set; }
         public string? Nickname { get; set; }
         public string? Avatar { get; set; }
-        public int UserLevel { get; set; } = 1;
-        public int TotalExperience { get; set; } = 0;
-        public int CurrentExperience { get; set; } = 0;
+        public string? Bio { get; set; }
+        public int TotalXp { get; set; } = 0;
         public int CompletedQuests { get; set; } = 0;
         public int TotalQuests { get; set; } = 0;
-        public string? Bio { get; set; }
 
         public Account Account { get; set; } = null!;
         public ICollection<UserProfile_Badge> UserProfile_Badges { get; set; } = [];

--- a/Infrastructure/Migrations/20250405130830_RemovedUnnecessaryLevelingFields.Designer.cs
+++ b/Infrastructure/Migrations/20250405130830_RemovedUnnecessaryLevelingFields.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250405130830_RemovedUnnecessaryLevelingFields")]
+    partial class RemovedUnnecessaryLevelingFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20250405130830_RemovedUnnecessaryLevelingFields.cs
+++ b/Infrastructure/Migrations/20250405130830_RemovedUnnecessaryLevelingFields.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemovedUnnecessaryLevelingFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CurrentExperience",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "UserLevel",
+                table: "UserProfiles");
+
+            migrationBuilder.RenameColumn(
+                name: "TotalExperience",
+                table: "UserProfiles",
+                newName: "TotalXp");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "TotalXp",
+                table: "UserProfiles",
+                newName: "TotalExperience");
+
+            migrationBuilder.AddColumn<int>(
+                name: "CurrentExperience",
+                table: "UserProfiles",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UserLevel",
+                table: "UserProfiles",
+                type: "int",
+                nullable: false,
+                defaultValue: 1);
+        }
+    }
+}

--- a/Infrastructure/Persistence/Configuration/UserProfileConfiguration.cs
+++ b/Infrastructure/Persistence/Configuration/UserProfileConfiguration.cs
@@ -18,15 +18,7 @@ namespace Infrastructure.Persistence.Configuration
             builder.Property(p => p.Avatar)
                 .IsRequired(false);
 
-            builder.Property(p => p.UserLevel)
-                .IsRequired()
-                .HasDefaultValue(1);
-
-            builder.Property(p => p.TotalExperience)
-                .IsRequired()
-                .HasDefaultValue(0);
-
-            builder.Property(p => p.CurrentExperience)
+            builder.Property(p => p.TotalXp)
                 .IsRequired()
                 .HasDefaultValue(0);
 

--- a/Infrastructure/Repositories/Quests/QuestRepository.cs
+++ b/Infrastructure/Repositories/Quests/QuestRepository.cs
@@ -197,8 +197,7 @@ namespace Infrastructure.Repositories.Quests
                         AccountId = q.AccountId,
                         TotalQuests = q.Account.Profile.TotalQuests,
                         CompletedQuests = q.Account.Profile.CompletedQuests,
-                        TotalExperience = q.Account.Profile.TotalExperience,
-                        CurrentExperience = q.Account.Profile.CurrentExperience,
+                        TotalXp = q.Account.Profile.TotalXp,
                         CreatedAt = q.Account.Profile.CreatedAt,
                         UpdatedAt = q.Account.Profile.UpdatedAt,
                         UserProfile_Badges = q.Account.Profile.UserProfile_Badges.Select(upb => new UserProfile_Badge


### PR DESCRIPTION
This pull request introduces a new leveling system to the application, which includes changes to configuration, data models, services, and tests. The most important changes include the addition of a leveling configuration, the implementation of a leveling service, and updates to various parts of the application to integrate the new leveling system.

### Leveling Configuration and Service:

* [`Api/Program.cs`](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR7): Added `LevelingOptions` configuration and registered `ILevelingService` as a singleton. [[1]](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR7) [[2]](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR188) [[3]](diffhunk://#diff-a6ed996e3026b38e5c72afe4e0dc000c16f9756f41c24baef20e36471b51b19dR223)
* [`Api/appsettings.json`](diffhunk://#diff-a55f760ee21b20e62926e1ed2dc867f013048056bd1b0a439a6502e1f3c4e6fcL25-R70): Added new leveling configuration with `MaxLevel` and `Curve` settings.
* [`Application/Configurations/Leveling/LevelingOptions.cs`](diffhunk://#diff-9b0a0b6749f8aa92a5f46abb4e3d6a7d2fda73ab06ec323e888093fb96c401b1R1-R16): Defined `LevelingOptions` and `LevelDefinition` classes to represent leveling configuration.
* [`Application/Services/LevelingService.cs`](diffhunk://#diff-bca76e39e14beb5a3611fba4719a1d578f99b39e430d4c3a2a40e446b6308ca6R1-R46): Implemented `LevelingService` to calculate user level based on total XP.

### Data Model Updates:

* [`Domain/Models/UserProfile.cs`](diffhunk://#diff-96ff6bdf22ca34acc4487806ab4aa80de43a06d485037f1c6b3b127dd36458e1L11-L16): Removed unnecessary fields (`UserLevel`, `CurrentExperience`, `TotalExperience`) and added `TotalXp`.
* [`Infrastructure/Migrations/20250405130830_RemovedUnnecessaryLevelingFields.cs`](diffhunk://#diff-57163e78525134898d53df429887db3f6896c4acc0046c956b11f2b179b27335R1-R50): Migration to remove old leveling fields and rename `TotalExperience` to `TotalXp`.
* [`Application/Models/LevelInfo.cs`](diffhunk://#diff-cd7c3b026927b6245510b11921c146c90f370f84aaf7882667676b27336bcc05R1-R10): Created `LevelInfo` record to represent leveling information.

### DTO and Mapping Updates:

* [`Application/Dtos/Accounts/GetAccountDto.cs`](diffhunk://#diff-789d90e1552752f005ff9cdd9f74a575c8b3ad04467d57ba2eb4eb5ab5f319d2L11-R14): Updated DTO to include new leveling fields (`UserXp`, `NextLevelTotalXpRequired`, `IsMaxLevel`).
* [`Application/MappingActions/SetUserLevelAction.cs`](diffhunk://#diff-8c5f70392bc6f0ba63b481d27e48e75623623fd6c580d184ec7ae18c8e306737R1-R33): Created mapping action to set user level information in `GetAccountDto`.
* [`Application/MappingProfiles/AccountProfile.cs`](diffhunk://#diff-e775fd1c8e02adec318f6c9b282f52eef6b2dbe6ead272305835418d19c33743R2): Updated mapping profile to use `SetUserLevelAction` for setting leveling info. [[1]](diffhunk://#diff-e775fd1c8e02adec318f6c9b282f52eef6b2dbe6ead272305835418d19c33743R2) [[2]](diffhunk://#diff-e775fd1c8e02adec318f6c9b282f52eef6b2dbe6ead272305835418d19c33743R14-R24)

### Service and Repository Updates:

* [`Application/Services/Quests/QuestService.cs`](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R175-R183): Added XP gain logic when updating quest completion.
* [`Infrastructure/Repositories/Quests/QuestRepository.cs`](diffhunk://#diff-f5568ec40509c0bac53d847f6cb5f0b1466fee1b750859cbb43e4b81c006720dL200-R200): Updated projection to use `TotalXp` instead of old experience fields.

### Test Updates:

* [`Tests/Services/AccountServiceTests.cs`](diffhunk://#diff-d6d125b72b55f3118362f7e011d31c33d9e7ed54de1cc0b55dc0d7c1e2547155L3): Updated tests to mock `IMapper` and verify new leveling fields in `GetAccountDto`. [[1]](diffhunk://#diff-d6d125b72b55f3118362f7e011d31c33d9e7ed54de1cc0b55dc0d7c1e2547155L3) [[2]](diffhunk://#diff-d6d125b72b55f3118362f7e011d31c33d9e7ed54de1cc0b55dc0d7c1e2547155L23-R28) [[3]](diffhunk://#diff-d6d125b72b55f3118362f7e011d31c33d9e7ed54de1cc0b55dc0d7c1e2547155L53-R67)