### PR TITLE
Fixed returning quests on today quests endpoint

### DIFF
--- a/Application/Services/Quests/QuestService.cs
+++ b/Application/Services/Quests/QuestService.cs
@@ -198,6 +198,10 @@ namespace Application.Services.Quests
 
             DateTime todayStart = nowLocal.Date.AtStartOfDayInZone(userTimezone).ToDateTimeUtc();
             DateTime todayEnd = todayStart.AddDays(1).AddTicks(-1);
+            _logger.LogInformation("Today start: {TodayStart}, Today end: {TodayEnd}",
+                todayStart.ToString("yyyy-MM-dd HH:mm:ss.fffffff"),
+                todayEnd.ToString("yyyy-MM-dd HH:mm:ss.fffffff"));
+
 
             SeasonEnum currentSeason = SeasonHelper.GetCurrentSeason();
 

--- a/Infrastructure/Repositories/Quests/QuestRepository.cs
+++ b/Infrastructure/Repositories/Quests/QuestRepository.cs
@@ -32,27 +32,31 @@ namespace Infrastructure.Repositories.Quests
                 .Where(q => q.AccountId == accountId)
                 .Where(q =>
                     (q.QuestType == QuestTypeEnum.OneTime &&
-                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
-                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd &&
+                        (q.StartDate ?? DateTime.MinValue) <= todayEnd &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayStart &&
                         (q.StartDate.HasValue || q.EndDate.HasValue))
 
                     || (q.QuestType == QuestTypeEnum.Daily &&
-                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
-                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd)
+                        (q.StartDate ?? DateTime.MinValue) <= todayEnd &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayStart)
 
                     || (q.QuestType == QuestTypeEnum.Weekly &&
-                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
-                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd &&
-                        (q.WeeklyQuest_Days.Any(wd => wd.Weekday == (WeekdayEnum)todayStart.DayOfWeek)))
+                        (q.StartDate ?? DateTime.MinValue) <= todayEnd &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayStart &&
+                        q.WeeklyQuest_Days.Any(wd =>
+                            wd.Weekday == (WeekdayEnum)todayStart.DayOfWeek ||
+                            wd.Weekday == (WeekdayEnum)todayEnd.DayOfWeek))
 
                     || (q.QuestType == QuestTypeEnum.Monthly &&
-                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
-                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd &&
-                        (q.MonthlyQuest_Days!.StartDay <= todayStart.Day && q.MonthlyQuest_Days.EndDay >= todayEnd.Day))
+                        (q.StartDate ?? DateTime.MinValue) <= todayEnd &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayStart &&
+                        ((q.MonthlyQuest_Days!.StartDay <= todayStart.Day && q.MonthlyQuest_Days.EndDay >= todayStart.Day)
+                        ||
+                        (q.MonthlyQuest_Days.StartDay <= todayEnd.Day && q.MonthlyQuest_Days.EndDay >= todayEnd.Day)))
 
                     || (q.QuestType == QuestTypeEnum.Seasonal &&
-                        (q.StartDate ?? DateTime.MinValue) <= todayStart &&
-                        (q.EndDate ?? DateTime.MaxValue) >= todayEnd &&
+                        (q.StartDate ?? DateTime.MinValue) <= todayEnd &&
+                        (q.EndDate ?? DateTime.MaxValue) >= todayStart &&
                         (q.SeasonalQuest_Season!.Season == currentSeason))
                 )
                 .Include(q => q.Quest_QuestLabels)


### PR DESCRIPTION
This pull request includes changes to improve the logging and accuracy of quest retrieval in the `QuestService` and `QuestRepository` classes. The most important changes include adding detailed logging for quest date ranges and correcting the date comparisons for quest retrieval.

Logging Improvements:

* [`Application/Services/Quests/QuestService.cs`](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R201-R204): Added logging to output the start and end times for the current day in the `GetActiveQuestsAsync` method.

Date Comparison Corrections:

* [`Infrastructure/Repositories/Quests/QuestRepository.cs`](diffhunk://#diff-f5568ec40509c0bac53d847f6cb5f0b1466fee1b750859cbb43e4b81c006720dL35-R59): Corrected the date comparisons in the `GetActiveQuestsAsync` method to ensure quests are accurately retrieved based on their start and end dates.