### PR TITLE
111 delete obsolete field textcolor from quest labels

### DIFF
--- a/Application/Dtos/Labels/CreateQuestLabelDto.cs
+++ b/Application/Dtos/Labels/CreateQuestLabelDto.cs
@@ -8,7 +8,6 @@ namespace Application.Dtos.Labels
         // This ensures FluentValidation handles validation instead of returning a generic 400 response.
         public string Value { get; set; } = string.Empty;
         public string BackgroundColor { get; set; } = string.Empty;
-        public string TextColor { get; set; } = string.Empty;
         [JsonIgnore]
         public int AccountId { get; set; }
     }

--- a/Application/Dtos/Labels/GetQuestLabelDto.cs
+++ b/Application/Dtos/Labels/GetQuestLabelDto.cs
@@ -5,6 +5,5 @@
         public int Id { get; set; }
         public string Value { get; set; } = string.Empty; // Prevents ASP.NET Core default validation errors.
         public string BackgroundColor { get; set; } = string.Empty;// Prevents ASP.NET Core default validation errors.
-        public string TextColor { get; set; } = string.Empty; // Prevents ASP.NET Core default validation errors.
     }
 }

--- a/Application/Dtos/Labels/PatchQuestLabelDto.cs
+++ b/Application/Dtos/Labels/PatchQuestLabelDto.cs
@@ -4,6 +4,5 @@
     {
         public string? Value { get; set; }
         public string? BackgroundColor { get; set; }
-        public string? TextColor { get; set; }
     }
 }

--- a/Application/MappingProfiles/DailyQuestProfile.cs
+++ b/Application/MappingProfiles/DailyQuestProfile.cs
@@ -21,7 +21,6 @@ namespace Application.MappingProfiles
                         Id = ql.QuestLabel.Id,
                         Value = ql.QuestLabel.Value,
                         BackgroundColor = ql.QuestLabel.BackgroundColor,
-                        TextColor = ql.QuestLabel.TextColor
                     }).ToList()));
 
             // Create DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/MonthlyQuestProfile.cs
+++ b/Application/MappingProfiles/MonthlyQuestProfile.cs
@@ -21,7 +21,6 @@ namespace Application.MappingProfiles
                         Id = ql.QuestLabel.Id,
                         Value = ql.QuestLabel.Value,
                         BackgroundColor = ql.QuestLabel.BackgroundColor,
-                        TextColor = ql.QuestLabel.TextColor
                     }).ToList()))
                 .ForMember(dest => dest.StartDay, opt => opt.MapFrom(src => src.MonthlyQuest_Days!.StartDay))
                 .ForMember(dest => dest.EndDay, opt => opt.MapFrom(src => src.MonthlyQuest_Days!.EndDay));

--- a/Application/MappingProfiles/OneTimeQuestProfile.cs
+++ b/Application/MappingProfiles/OneTimeQuestProfile.cs
@@ -20,7 +20,6 @@ namespace Application.MappingProfiles
                     Id = ql.QuestLabel.Id,
                     Value = ql.QuestLabel.Value,
                     BackgroundColor = ql.QuestLabel.BackgroundColor,
-                    TextColor = ql.QuestLabel.TextColor
                 }).ToList()));
 
             // Create DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/SeasonalQuestProfile.cs
+++ b/Application/MappingProfiles/SeasonalQuestProfile.cs
@@ -21,7 +21,6 @@ namespace Application.MappingProfiles
                     Id = ql.QuestLabel.Id,
                     Value = ql.QuestLabel.Value,
                     BackgroundColor = ql.QuestLabel.BackgroundColor,
-                    TextColor = ql.QuestLabel.TextColor
                 }).ToList()));
 
             // Create DTO -> Entity (Convert String -> Enum)

--- a/Application/MappingProfiles/WeeklyQuestProfile.cs
+++ b/Application/MappingProfiles/WeeklyQuestProfile.cs
@@ -22,7 +22,6 @@ namespace Application.MappingProfiles
                     Id = ql.QuestLabelId,
                     Value = ql.QuestLabel.Value,
                     BackgroundColor = ql.QuestLabel.BackgroundColor,
-                    TextColor = ql.QuestLabel.TextColor
                 }).ToList()));
 
             // Create DTO -> Entity (Convert String -> Enum)

--- a/Application/Validators/QuestLabels/CreateQuestLabelValidator.cs
+++ b/Application/Validators/QuestLabels/CreateQuestLabelValidator.cs
@@ -14,10 +14,6 @@ namespace Application.Validators.QuestLabels
             RuleFor(x => x.BackgroundColor)
                 .NotEmpty().WithMessage("{PropertyName} is required")
                 .MaximumLength(7).WithMessage("{PropertyName} must not exceed {MaxLength} characters");
-
-            RuleFor(x => x.TextColor)
-                .NotEmpty().WithMessage("{PropertyName} is required")
-                .MaximumLength(7).WithMessage("{PropertyName} must not exceed {MaxLength} characters");
         }
     }
 }

--- a/Application/Validators/QuestLabels/PatchQuestLabelValidator.cs
+++ b/Application/Validators/QuestLabels/PatchQuestLabelValidator.cs
@@ -12,9 +12,6 @@ namespace Application.Validators.QuestLabels
 
             RuleFor(x => x.BackgroundColor)
                 .MaximumLength(7).WithMessage("{PropertyName} must not exceed {MaxLength} characters");
-
-            RuleFor(x => x.TextColor)
-                .MaximumLength(7).WithMessage("{PropertyName} must not exceed {MaxLength} characters");
         }
     }
 }

--- a/Domain/Models/QuestLabel.cs
+++ b/Domain/Models/QuestLabel.cs
@@ -8,19 +8,17 @@ namespace Domain.Models
         public int AccountId { get; set; }
         public required string Value { get; set; }
         public required string BackgroundColor { get; set; }
-        public required string TextColor { get; set; }
 
         public Account Account { get; set; } = null!;
         public ICollection<Quest_QuestLabel> Quest_QuestLabels { get; set; } = null!;
 
         public QuestLabel() { }
-        public QuestLabel(int id, int accountId, string value, string backgroundColor, string textColor)
+        public QuestLabel(int id, int accountId, string value, string backgroundColor)
         {
             Id = id;
             AccountId = accountId;
             Value = value;
             BackgroundColor = backgroundColor;
-            TextColor = textColor;
         }
     }
 }

--- a/Infrastructure/Migrations/20250512190105_DeleteTextColorFromQuestLabels.Designer.cs
+++ b/Infrastructure/Migrations/20250512190105_DeleteTextColorFromQuestLabels.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250512190105_DeleteTextColorFromQuestLabels")]
+    partial class DeleteTextColorFromQuestLabels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Migrations/20250512190105_DeleteTextColorFromQuestLabels.cs
+++ b/Infrastructure/Migrations/20250512190105_DeleteTextColorFromQuestLabels.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class DeleteTextColorFromQuestLabels : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TextColor",
+                table: "Quest_Labels");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TextColor",
+                table: "Quest_Labels",
+                type: "nvarchar(7)",
+                maxLength: 7,
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/Infrastructure/Persistence/Configuration/QuestLabelConfiguration.cs
+++ b/Infrastructure/Persistence/Configuration/QuestLabelConfiguration.cs
@@ -21,10 +21,6 @@ namespace Infrastructure.Persistence.Configuration
                 .IsRequired()
                 .HasMaxLength(7);
 
-            builder.Property(ql => ql.TextColor)
-                .IsRequired()
-                .HasMaxLength(7);
-
             builder.HasOne(ql => ql.Account)
                 .WithMany(a => a.Labels)
                 .HasForeignKey(ql => ql.AccountId)

--- a/Infrastructure/Repositories/Quests/QuestRepository.cs
+++ b/Infrastructure/Repositories/Quests/QuestRepository.cs
@@ -243,7 +243,6 @@ namespace Infrastructure.Repositories.Quests
                         AccountId = q.AccountId,
                         Value = ql.QuestLabel.Value,
                         BackgroundColor = ql.QuestLabel.BackgroundColor,
-                        TextColor = ql.QuestLabel.TextColor,
                         UpdatedAt = ql.QuestLabel.UpdatedAt,
                         CreatedAt = ql.QuestLabel.CreatedAt
                     }

--- a/Tests/Factories/QuestLabelFactory.cs
+++ b/Tests/Factories/QuestLabelFactory.cs
@@ -15,7 +15,6 @@ namespace Tests.Factories
                 AccountId = accountId,
                 Value = text,
                 BackgroundColor = "backgroundColor",
-                TextColor = "textColor"
             };
         }
     }


### PR DESCRIPTION
## Pull Request: Remove Obsolete `textColor` Field from `label` Object

This pull request removes the `textColor` field from the `label` object. This field is considered obsolete and is no longer used by the application.

**Affected Endpoints:**

This change impacts all API endpoints that utilize the `label` object. Please review the following endpoint categories and ensure compatibility:

*   Endpoints creating or updating labels
*   Endpoints retrieving labels
*   Endpoints retrieving quests

**Reasoning:**

The `textColor` field was initially included on the `label` object to specify the text color. The front-end now dynamically determines the best contrasting text color based on the `backgroundColor` of the label. Therefore, explicitly specifying `textColor` is redundant and the field has been removed to simplify the `label` object and ensure consistency.

**Migration Notes:**

Client applications no longer need to specify a `textColor`. The front-end will automatically determine the appropriate text color based on the `backgroundColor` of the label. Please ensure your applications are compatible with this change.

**Testing:**

*   All API endpoints that utilize the `label` object have been tested to ensure that they function correctly without the `textColor` field.
*   The front-end's dynamic text color determination has been verified to provide adequate contrast and readability across a variety of `backgroundColor` values.
*   The removal of the `textColor` field has been verified to not introduce any regressions or other issues.

By removing the unused `textColor` field, this PR simplifies the codebase and ensures consistent label styling.