### PR TITLE
New endpoint to return extended user stats

### DIFF
--- a/Api/Controllers/StatsController.cs
+++ b/Api/Controllers/StatsController.cs
@@ -1,4 +1,5 @@
-﻿using Application.Dtos.UserProfileStats;
+﻿using Application.Dtos.Stats;
+using Application.Dtos.UserProfileStats;
 using Application.Interfaces;
 using Domain;
 using Domain.Exceptions;
@@ -28,17 +29,19 @@ namespace Api.Controllers
 
             var profileStats = await _statsService.GetUserProfileStatsAsync(accountId, cancellationToken).ConfigureAwait(false);
 
-            if (profileStats is null)
-            {
-                return NotFound(new ProblemDetails
-                {
-                    Status = StatusCodes.Status404NotFound,
-                    Title = "Quest not found",
-                    Detail = $"Profile with account ID {accountId} was not found"
-                });
-            }
-
             return Ok(profileStats);
+        }
+
+        [HttpGet("extended")]
+        public async Task<ActionResult<GetUserExtendedStatsDto>> GetUserExtendedStats(CancellationToken cancellationToken = default)
+        {
+            string? accountIdString = User.FindFirst(JwtClaimTypes.AccountId)?.Value;
+            if (string.IsNullOrWhiteSpace(accountIdString) || !int.TryParse(accountIdString, out int accountId))
+                throw new UnauthorizedException("Invalid access token: missing account identifier.");
+
+            var extendedStats = await _statsService.GetUserExtendedStatsAsync(accountId, cancellationToken).ConfigureAwait(false);
+
+            return Ok(extendedStats);
         }
     }
 }

--- a/Application/Dtos/Stats/GetUserExtendedStatsDto.cs
+++ b/Application/Dtos/Stats/GetUserExtendedStatsDto.cs
@@ -1,0 +1,11 @@
+﻿using Application.Dtos.UserProfileStats;
+
+namespace Application.Dtos.Stats
+{
+    public class GetUserExtendedStatsDto
+    {
+        public QuestExtendedStatsDto QuestStats { get; set; } = new();
+        public GoalExtendedStatsDto GoalStats { get; set; } = new();
+        public XpProgressDto XpStats { get; set; } = new();
+    }
+}

--- a/Application/Dtos/Stats/GoalExtendedStatsDto.cs
+++ b/Application/Dtos/Stats/GoalExtendedStatsDto.cs
@@ -1,0 +1,12 @@
+﻿namespace Application.Dtos.Stats
+{
+    public class GoalExtendedStatsDto
+    {
+        public int CurrentTotal { get; set; }
+        public int CurrentCompleted { get; set; }
+        public int InProgress { get; set; }
+        public int TotalCreated { get; set; }
+        public int TotalCompleted { get; set; }
+        public int TotalExpired { get; set; }
+    }
+}

--- a/Application/Dtos/Stats/QuestExtendedStatsDto.cs
+++ b/Application/Dtos/Stats/QuestExtendedStatsDto.cs
@@ -1,0 +1,11 @@
+﻿namespace Application.Dtos.Stats
+{
+    public class QuestExtendedStatsDto
+    {
+        public int TotalCreated { get; set; }
+        public int TotalCompleted { get; set; }
+        public int CurrentTotal { get; set; }
+        public int CurrentEverCompleted { get; set; }
+        public int CurrentCompleted { get; set; }
+    }
+}

--- a/Application/Interfaces/IStatsService.cs
+++ b/Application/Interfaces/IStatsService.cs
@@ -1,9 +1,11 @@
-﻿using Application.Dtos.UserProfileStats;
+﻿using Application.Dtos.Stats;
+using Application.Dtos.UserProfileStats;
 
 namespace Application.Interfaces
 {
     public interface IStatsService
     {
         Task<GetUserProfileStatsDto> GetUserProfileStatsAsync(int accountId, CancellationToken cancellationToken = default);
+        Task<GetUserExtendedStatsDto> GetUserExtendedStatsAsync(int accountId, CancellationToken cancellationToken = default);
     }
 }

--- a/Application/MappingActions/SetGoalExtendedStatsAction.cs
+++ b/Application/MappingActions/SetGoalExtendedStatsAction.cs
@@ -1,0 +1,21 @@
+﻿using Application.Dtos.Stats;
+using AutoMapper;
+using Domain.Models;
+
+namespace Application.MappingActions
+{
+    internal class SetGoalExtendedStatsAction : IMappingAction<UserProfile, GoalExtendedStatsDto>
+    {
+        public void Process(UserProfile source, GoalExtendedStatsDto destination, ResolutionContext context)
+        {
+            var goals = source.Account.UserGoals;
+
+            destination.CurrentTotal = source.ActiveGoals;
+            destination.CurrentCompleted = goals.Count(g => !g.IsExpired && g.IsAchieved);
+            destination.InProgress = source.ActiveGoals - destination.CurrentCompleted;
+            destination.TotalCreated = source.TotalGoals;
+            destination.TotalCompleted = source.CompletedGoals;
+            destination.TotalExpired = source.ExpiredGoals;
+        }
+    }
+}

--- a/Application/MappingProfiles/ExtendedStatsProfile.cs
+++ b/Application/MappingProfiles/ExtendedStatsProfile.cs
@@ -1,0 +1,32 @@
+﻿using Application.Dtos.Stats;
+using Application.Dtos.UserProfileStats;
+using Application.MappingActions;
+using AutoMapper;
+using Domain.Models;
+
+namespace Application.MappingProfiles
+{
+    public class ExtendedStatsProfile : Profile
+    {
+        public ExtendedStatsProfile()
+        {
+            CreateMap<UserProfile, GetUserExtendedStatsDto>()
+                .ForMember(dest => dest.QuestStats, opt => opt.MapFrom(src => src))
+                .ForMember(dest => dest.GoalStats, opt => opt.MapFrom(src => src))
+                .ForMember(dest => dest.XpStats, opt => opt.MapFrom(src => src));
+
+            CreateMap<UserProfile, QuestExtendedStatsDto>()
+                .ForMember(dest => dest.CurrentTotal, opt => opt.MapFrom(src => src.ExistingQuests))
+                .ForMember(dest => dest.CurrentEverCompleted, opt => opt.MapFrom(src => src.EverCompletedExistingQuests))
+                .ForMember(dest => dest.CurrentCompleted, opt => opt.MapFrom(src => src.CurrentlyCompletedExistingQuests))
+                .ForMember(dest => dest.TotalCreated, opt => opt.MapFrom(src => src.TotalQuests))
+                .ForMember(dest => dest.TotalCompleted, opt => opt.MapFrom(src => src.CompletedQuests));
+
+            CreateMap<UserProfile, GoalExtendedStatsDto>()
+                .AfterMap<SetGoalExtendedStatsAction>();
+
+            CreateMap<UserProfile, XpProgressDto>()
+                .AfterMap<SetUserLevelAction>();
+        }
+    }
+}

--- a/Application/Services/StatsService.cs
+++ b/Application/Services/StatsService.cs
@@ -1,4 +1,5 @@
-﻿using Application.Dtos.UserProfileStats;
+﻿using Application.Dtos.Stats;
+using Application.Dtos.UserProfileStats;
 using Application.Interfaces;
 using AutoMapper;
 using Domain.Exceptions;
@@ -23,6 +24,14 @@ namespace Application.Services
                 ?? throw new NotFoundException($"User profile for account ID {accountId} was not found.");
 
             return _mapper.Map<GetUserProfileStatsDto>(userProfile);
+        }
+
+        public async Task<GetUserExtendedStatsDto> GetUserExtendedStatsAsync(int accountId, CancellationToken cancellationToken = default)
+        {
+            var userProfile = await _unitOfWork.UserProfiles.GetUserProfileWithGoalsAsync(accountId, cancellationToken).ConfigureAwait(false)
+                ?? throw new NotFoundException($"User profile for account ID {accountId} was not found.");
+
+            return _mapper.Map<GetUserExtendedStatsDto>(userProfile);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature to provide extended user statistics in the application. The most notable changes include the addition of a new DTO (`GetUserExtendedStatsDto`), updates to the `StatsController` to support an endpoint for extended stats, and the implementation of mapping and service logic to compute and return these extended stats.

### API Enhancements:
* Added a new endpoint `GetUserExtendedStats` in `StatsController` to retrieve extended user statistics. This endpoint validates the account ID from the JWT token and fetches the data using the stats service. (`[Api/Controllers/StatsController.csL31-R44](diffhunk://#diff-d16c9c35d52859ccb8fe69822459482d629b2b3a2aa99789da2c69fa72620172L31-R44)`)

### Data Transfer Objects (DTOs):
* Introduced `GetUserExtendedStatsDto` to encapsulate extended statistics, including `QuestStats`, `GoalStats`, and `XpStats`. (`[Application/Dtos/Stats/GetUserExtendedStatsDto.csR1-R11](diffhunk://#diff-5394340b1eec608a03e1981c04870c141945b2b1a89d1952bb779a074e0b9723R1-R11)`)
* Added `GoalExtendedStatsDto` to represent goal-related statistics such as total goals created, completed, and expired. (`[Application/Dtos/Stats/GoalExtendedStatsDto.csR1-R12](diffhunk://#diff-1ec5fbb6058547abaa735912c5183f869e2f76bc8e0baaa05a33f0c09300cf82R1-R12)`)
* Added `QuestExtendedStatsDto` to represent quest-related statistics such as total quests created, completed, and currently active. (`[Application/Dtos/Stats/QuestExtendedStatsDto.csR1-R11](diffhunk://#diff-844e893c079e3186f751c240b24dd76925e3b3564f4cf25045c6ab8f2f73bcbaR1-R11)`)

### Service and Mapping Logic:
* Updated `IStatsService` and its implementation to include a new method `GetUserExtendedStatsAsync`, which retrieves and maps extended statistics for a user profile. (`[[1]](diffhunk://#diff-7601e0027ba2e8c50eb6e2749627b7e54c1d5a3b99fd10edb24e76fee696318cL1-R9)`, `[[2]](diffhunk://#diff-fa051204102e3094ecf68bc9eee5951435f89814fbe22a97aa64d45aaa90b1afR28-R35)`)
* Added `ExtendedStatsProfile` mapping profile to configure mappings for extended statistics, including custom mapping actions for goals and quests. (`[Application/MappingProfiles/ExtendedStatsProfile.csR1-R32](diffhunk://#diff-450dc5d2963a798546572074823f606d2cd4439aee623b6843a88ef4cd82a20eR1-R32)`)
* Implemented `SetGoalExtendedStatsAction` to calculate and populate goal-related extended statistics during mapping. (`[Application/MappingActions/SetGoalExtendedStatsAction.csR1-R21](diffhunk://#diff-c3c176dbb6b4eea10035085f31b598ae6d20243c712e6ef9edb5512dec898ba3R1-R21)`)