### PR TITLE
Added validation if user tries to uncomplete quest that is active goal

### DIFF
--- a/Application/Services/Quests/QuestService.cs
+++ b/Application/Services/Quests/QuestService.cs
@@ -211,6 +211,12 @@ namespace Application.Services.Quests
                 return;
             }
 
+            if (patchDto.IsCompleted == false && existingQuest.UserGoal is not null)
+            {
+                _logger.LogError("Cannot uncomplete a quest that is active goals. Quest ID: {QuestId}", existingQuest.Id);
+                throw new ConflictException("Cannot uncomplete a quest that is active goals.");
+            }
+
             var nowUtc = SystemClock.Instance.GetCurrentInstant();
 
             var completionContext = await BuildCompletionContextAsync(existingQuest, patchDto, nowUtc, cancellationToken);


### PR DESCRIPTION
This pull request includes a validation improvement in the `QuestService` to prevent quests with active goals from being marked as incomplete.

Validation enhancement:

* [`Application/Services/Quests/QuestService.cs`](diffhunk://#diff-07519a98d10f94dddf47d64ae515bc7654c3a970fd7d736f2a601d77396993a6R214-R219): Added a check to ensure that a quest with active goals cannot be marked as incomplete, logging an error and throwing a `ConflictException` if such an attempt is made.