### PR TITLE
Explicitly installed System.IdentityModel.Tokens.Jwt

### DIFF
--- a/Infrastructure/Authentication/TokenValidator.cs
+++ b/Infrastructure/Authentication/TokenValidator.cs
@@ -42,7 +42,7 @@ namespace Infrastructure.Authentication
             }
             catch (Exception)
             {
-                throw new InvalidArgumentException("Invalid refresh token");
+                throw;
             }
 
             return principal ?? throw new UnauthorizedException("Invalid refresh token");

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Package was previously transitive which caused mismatched versions and made security token handler unable to read claims.