### PR TITLE
Repaired logic for generating quest occurrences

### DIFF
--- a/Application/Services/Quests/QuestOccurrencesGenerator.cs
+++ b/Application/Services/Quests/QuestOccurrencesGenerator.cs
@@ -26,7 +26,7 @@ namespace Application.Services.Quests
         public async Task<List<QuestOccurrence>> GenerateMissingOccurrencesForQuestAsync(Quest quest, CancellationToken cancellationToken = default)
         {
             var now = _clock.GetCurrentInstant().ToDateTimeUtc();
-            var lastDate = quest.LastCompletedAt ?? now;
+            var lastDate = quest.LastCompletedAt ?? quest.StartDate ?? quest.CreatedAt;
 
             var windows = QuestWindowCalculator.GenerateWindows(quest, lastDate, now);
             var newOccurrences = new List<QuestOccurrence>();
@@ -47,27 +47,47 @@ namespace Application.Services.Quests
 
         public async Task<int> GenerateAndSaveMissingOccurrencesForQuestsAsync(CancellationToken cancellationToken = default)
         {
-            var repeatableQuests = await _unitOfWork.Quests.GetRepeatableQuestsAsync(true, cancellationToken);
+            var now = _clock.GetCurrentInstant().ToDateTimeUtc();
+            // Fetch all active repeatable quests with their occurrences
+            var repeatableQuests = await _unitOfWork.Quests.GetRepeatableQuestsForOccurrencesProcessingAsync(now, cancellationToken);
+
             _logger.LogDebug("Found {Count} repeatable quests to process.", repeatableQuests.Count());
 
-            List<QuestOccurrence> allNewOccurrences = [];
+            var allNewOcurrencesToSave = new List<QuestOccurrence>();
+
             foreach (var quest in repeatableQuests)
             {
-                var newOccurrencesForQuest = await GenerateMissingOccurrencesForQuestAsync(quest, cancellationToken);
-                if (newOccurrencesForQuest.Count != 0)
+                var lastDate = quest.LastCompletedAt ?? quest.StartDate ?? quest.CreatedAt;
+                var windows = QuestWindowCalculator.GenerateWindows(quest, lastDate, now);
+
+                // Use HasSet for better performance when checking for existing occurrences
+                var existingQuestOccurrences = new HashSet<(DateTime Start, DateTime End)>(
+                    quest.QuestOccurrences.Select(qo => (qo.OccurrenceStart, qo.OccurrenceEnd)));
+
+                var newOccurrencesForThisQuest = new List<QuestOccurrence>();
+
+                foreach (var window in windows)
                 {
-                    _logger.LogDebug("Generated {Count} new occurrences for quest {QuestId}", newOccurrencesForQuest.Count, quest.Id);
-                    allNewOccurrences.AddRange(newOccurrencesForQuest);
+                    if (!existingQuestOccurrences.Contains((window.Start, window.End)))
+                    {
+                        newOccurrencesForThisQuest.Add(CreateOccurrence(quest.Id, window));
+                    }
+                }
+
+                if (newOccurrencesForThisQuest.Count != 0)
+                {
+                    _logger.LogDebug("Generated {Count} new occurrences for quest {QuestId}", newOccurrencesForThisQuest.Count, quest.Id);
+                    allNewOcurrencesToSave.AddRange(newOccurrencesForThisQuest);
                 }
             }
 
-            if (allNewOccurrences.Count == 0)
+            if (allNewOcurrencesToSave.Count == 0)
             {
                 _logger.LogInformation("No new occurrences needed to be generated for any quests.");
                 return 0;
             }
 
-            await _unitOfWork.QuestOccurrences.AddRangeAsync(allNewOccurrences, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.QuestOccurrences.AddRangeAsync(allNewOcurrencesToSave, cancellationToken).ConfigureAwait(false);
 
             int affectedRows = await _unitOfWork.SaveChangesAsync(cancellationToken);
             return affectedRows;

--- a/Application/Services/Quests/QuestWindowCalculator.cs
+++ b/Application/Services/Quests/QuestWindowCalculator.cs
@@ -16,7 +16,7 @@ namespace Application.Services.Quests
                 QuestTypeEnum.Daily => GenerateDailyWindows(fromUtc, toUtc, userZone),
                 QuestTypeEnum.Weekly => GenerateWeeklyWindows(quest, fromUtc, toUtc, userZone),
                 QuestTypeEnum.Monthly => GenerateMonthlyWindows(quest, fromUtc, toUtc, userZone),
-                _ => new List<TimeWindow>()
+                _ => []
             };
         }
 

--- a/Domain/Interfaces/Quests/IQuestRepository.cs
+++ b/Domain/Interfaces/Quests/IQuestRepository.cs
@@ -12,6 +12,7 @@ namespace Domain.Interfaces.Quests
         Task<Quest?> GetQuestForDisplayAsync(int questId, QuestTypeEnum questType, CancellationToken cancellationToken = default);
         Task<IEnumerable<Quest>> GetRepeatableQuestsAsync(bool asNoTracking, CancellationToken cancellationToken = default);
         Task<IEnumerable<Quest>> GetRepeatableQuestsForStatsProcessingAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<Quest>> GetRepeatableQuestsForOccurrencesProcessingAsync(DateTime nowUtc, CancellationToken cancellationToken = default);
         Task<Quest?> GetQuestForStatsProcessingAsync(int questId, CancellationToken cancellationToken = default);
         Task<bool> IsQuestOwnedByUserAsync(int questId, int accountId, CancellationToken cancellationToken = default);
         Task<IEnumerable<Quest>> GetQuestEligibleForGoalAsync(int accountId, DateTime now, CancellationToken cancellationToken = default);


### PR DESCRIPTION
To process new occurrences we now fetch only quests that are active:
- No start date or start data before today
- No end date or end date after today

Created new repository method for that purpose.

Refactored generating occurrences logic:
Moved all logic inside dedicated method.
Reference last date now takes LastCompletedAt, if not present it takes StartDate, if not present it takes CreatedAt.
We now fetch all quest occurrences and after generating new occurrences we check hash set for existence for duplicates.