### PR TITLE
Added sorting in repository method

### DIFF
--- a/Application/CommandsHandlers/UpdateQuestCompletionCommandHandler.cs
+++ b/Application/CommandsHandlers/UpdateQuestCompletionCommandHandler.cs
@@ -134,14 +134,17 @@ namespace Application.CommandsHandlers
         private async Task<QuestOccurrence?> GetOrCreateQuestOccurrenceAsync(Quest quest, DateTime nowUtc, CancellationToken cancellationToken)
         {
             var currentOccurrence = await _unitOfWork.QuestOccurrences.GetCurrentOccurrenceForQuestAsync(quest.Id, nowUtc, cancellationToken).ConfigureAwait(false);
+            _logger.LogDebug("Current occurrence for quest {QuestId} at {NowUtc}: {Start} {End}", quest.Id, nowUtc, currentOccurrence?.OccurrenceStart, currentOccurrence?.OccurrenceEnd);
             if (currentOccurrence is null)
             {
                 var missingOccurences = await _questOccurrenceGenerator.GenerateMissingOccurrencesForQuestAsync(quest, cancellationToken).ConfigureAwait(false);
                 currentOccurrence = missingOccurences.FirstOrDefault(o => o.OccurrenceStart <= nowUtc && o.OccurrenceEnd >= nowUtc);
+                _logger.LogDebug("Current occurrence for quest {QuestId} at {NowUtc}: {Start} {End}", quest.Id, nowUtc, currentOccurrence?.OccurrenceStart, currentOccurrence?.OccurrenceEnd);
             }
             if (currentOccurrence is null)
             {
                 currentOccurrence = await _unitOfWork.QuestOccurrences.GetLastOccurrenceForCompletionAsync(quest.Id, nowUtc, cancellationToken).ConfigureAwait(false);
+                _logger.LogDebug("Current occurrence for quest {QuestId} at {NowUtc}: {Start} {End}", quest.Id, nowUtc, currentOccurrence?.OccurrenceStart, currentOccurrence?.OccurrenceEnd);
                 if (currentOccurrence is null)
                     return null;
 

--- a/Infrastructure/Repositories/Quests/QuestOccurrenceRepository.cs
+++ b/Infrastructure/Repositories/Quests/QuestOccurrenceRepository.cs
@@ -36,6 +36,7 @@ namespace Infrastructure.Repositories.Quests
         public async Task<QuestOccurrence?> GetLastOccurrenceForCompletionAsync(int questId, DateTime now, CancellationToken cancellationToken = default)
         {
             return await _context.QuestOccurrences
+                .OrderByDescending(q => q.OccurrenceEnd)
                 .FirstOrDefaultAsync(q =>
                     q.QuestId == questId &&
                     q.OccurrenceEnd <= now,


### PR DESCRIPTION
Repository method laced `OrderByDescending(qo => qo.OccurrenceEnd)` method so it fetched first occurrence that met provided criteria instead of the latest occurrence.